### PR TITLE
ES6 syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /dist/scarletsframe.hot.js
 mynote.md
 /tests/
+package-lock.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,8 @@ gulp.task('js-es5', ()=>
               ie: "11"
             },
             modules: false,
-            loose: false
+            loose: false,
+            shippedProposals: true
           }
         ]
       ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,10 +129,12 @@ function swallowError(error){
 
 function removeOldMap(path){
   fs.readdir(path, function(err, files){
-     for (let i = 0, len = files.length; i < len; i++) {
-        if(files[i].match(/.*\.(js|css)\.map/) !== null){
-          try{fs.unlinkSync(path+files[i]);}catch(e){}
-        }
+     if (files) {
+       for (let i = 0, len = files.length; i < len; i++) {
+          if(files[i].match(/.*\.(js|css)\.map/) !== null){
+            try{fs.unlinkSync(path+files[i]);}catch(e){}
+          }
+       }
      }
   });
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,12 @@
-var gulp = require('gulp');
-var concat = require('gulp-concat');
-var sourcemaps = require('gulp-sourcemaps');
-var header = require('gulp-header');
-var rename = require('gulp-rename');
-var fs = require('fs');
-var notifier = require('node-notifier');
+const gulp = require('gulp');
+const concat = require('gulp-concat');
+const sourcemaps = require('gulp-sourcemaps');
+const header = require('gulp-header');
+const rename = require('gulp-rename');
+const fs = require('fs');
+const notifier = require('node-notifier');
 
-var compile, uglify, babel, fast;
+let compile, uglify, babel, fast;
 gulp.task('enableCompile', function(done){
   uglify = require('gulp-uglify-es').default;
   babel = require("gulp-babel");
@@ -15,9 +15,9 @@ gulp.task('enableCompile', function(done){
   done && done();
 });
 
-var dateMinify = {};
+const dateMinify = {};
 // var dateMinify = {mapFile:function(path){return path.replace('js.map', Date.now()+'.js.map')}};
-var theHeader = `/*
+const theHeader = `/*
   ScarletsFrame
   A frontend library for Scarlets Framework that support
   lazy page load and element binding that can help
@@ -26,7 +26,7 @@ var theHeader = `/*
   https://github.com/ScarletsFiction/ScarletsFrame
 */\n`;
 
-var theOrderES5 = [
+const theOrderES5 = [
   'src/sf-polyfill.js',
   'src/sf-a_init.js',
   'src/sf-loader.js',
@@ -40,8 +40,8 @@ var theOrderES5 = [
   'src/sf-z_end.js',
 ];
 
-var theOrderES6 = theOrderES5.slice(1);
-var devTest = theOrderES6.slice(0);
+const theOrderES6 = theOrderES5.slice(1);
+const devTest = theOrderES6.slice(0);
 devTest.splice(-2, 1); // Remove '!src/sf-hot-reload.js'
 
 gulp.task('watch-js', function(){
@@ -61,8 +61,8 @@ gulp.task('watch-js', function(){
     });
 });
 
-gulp.task('js-es5', function(){
-  return gulp.src(theOrderES5)
+gulp.task('js-es5', ()=>
+  gulp.src(theOrderES5)
     .pipe(sourcemaps.init())
     .pipe(concat('scarletsframe.js'))
     .pipe(gulp.dest('dist'))
@@ -84,28 +84,28 @@ gulp.task('js-es5', function(){
     .pipe(header(theHeader))
     .pipe(rename({extname:'.min.js'}))
     .pipe(sourcemaps.write('.', dateMinify))
-    .pipe(gulp.dest('dist'));
-});
+    .pipe(gulp.dest('dist'))
+);
 
-gulp.task('js-es6', function(){
-  return gulp.src(theOrderES6)
+gulp.task('js-es6', ()=>
+  gulp.src(theOrderES6)
     .pipe(sourcemaps.init())
     .pipe(concat('scarletsframe.es6.js'))
     .pipe(uglify())
     .pipe(header(theHeader))
     .pipe(sourcemaps.write('.', dateMinify))
-    .pipe(gulp.dest('dist'));
-});
+    .pipe(gulp.dest('dist'))
+);
 
-gulp.task('js-hot', function(){
-  return gulp.src(devTest)
+gulp.task('js-hot', ()=>
+  gulp.src(devTest)
     .pipe(sourcemaps.init())
     .pipe(concat('scarletsframe.hot.js'))
     .pipe(uglify())
     .pipe(header(theHeader))
     .pipe(sourcemaps.write('.', dateMinify))
-    .pipe(gulp.dest('dist'));
-});
+    .pipe(gulp.dest('dist'))
+);
 
 gulp.task('default', function(){
   require('./tests/server.js');
@@ -129,7 +129,7 @@ function swallowError(error){
 
 function removeOldMap(path){
   fs.readdir(path, function(err, files){
-     for (var i = 0, len = files.length; i < len; i++) {
+     for (let i = 0, len = files.length; i < len; i++) {
         if(files[i].match(/.*\.(js|css)\.map/) !== null){
           try{fs.unlinkSync(path+files[i]);}catch(e){}
         }

--- a/src/sf-api.js
+++ b/src/sf-api.js
@@ -39,9 +39,9 @@ class API{
 		else var options = {};
 
 		if(this.accessToken){
-			var accessToken = this.accessToken;
+			const { accessToken } = this;
 			options.beforeSend = function(xhr){
-			    xhr.setRequestHeader('X-Authorization', 'Bearer '+accessToken);
+			    xhr.setRequestHeader('X-Authorization', `Bearer ${accessToken}`);
 			    beforeSend && beforeSend(xhr);
 			}
 		}

--- a/src/sf-component.js
+++ b/src/sf-component.js
@@ -10,14 +10,14 @@ sf.component = function(name, options, func, namespace){
 			return sf.component.for(name, options, func, namespace);
 	}
 
-	var temp = sf.component.registered[name];
+	const temp = sf.component.registered[name];
 	return temp ? temp[2] : [];
 }
 
 function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 	tempDOM = temp.tempDOM || temp.tagName.toLowerCase() === name;
 
-	var isDynamic = internal.model.templateInjector(temp, newObj, true);
+	const isDynamic = internal.model.templateInjector(temp, newObj, true);
 	temp = sf.model.extractPreprocess(temp, null, newObj, void 0, registrar[4]);
 
 	if(isDynamic === false)
@@ -34,24 +34,24 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 }
 
 ;(function(){
-	var self = sf.component;
+	const self = sf.component;
 	internal.component = {};
 	internal.componentInherit = {};
 
-	var waitingHTML = {};
+	const waitingHTML = {};
 
 	self.registered = {};
 	// internal.component.tagName = new Set();
 
 	function checkWaiting(name, namespace){
-		var scope = namespace || self;
+		const scope = namespace || self;
 
-		var upgrade = waitingHTML[name];
-		for (var i = upgrade.length - 1; i >= 0; i--) {
+		const upgrade = waitingHTML[name];
+		for (let i = upgrade.length - 1; i >= 0; i--) {
 			if(upgrade[i].namespace !== namespace)
 				continue;
 
-			var el = upgrade[i].el;
+			let { el } = upgrade[i];
 			el = self.new(name, el, upgrade[i].item, namespace, false, true);
 			if(el === void 0)
 				return;
@@ -80,10 +80,10 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 		}
 
 		// internal.component.tagName.add(name.toUpperCase());
-		var scope = namespace || self;
+		const scope = namespace || self;
 
 		// 0=Function for scope, 1=DOM Contructor, 2=elements, 3=Template
-		var registrar = scope.registered[name];
+		let registrar = scope.registered[name];
 		if(registrar === void 0){
 			registrar = scope.registered[name] = new Array(5);
 			registrar[2] = [];
@@ -92,9 +92,9 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 
 		registrar[0] = func;
 
-		var construct = defineComponent(name);
+		const construct = defineComponent(name);
 		registrar[1] = construct;
-		window['$'+capitalizeLetters(name.split('-'))] = construct;
+		window[`$${capitalizeLetters(name.split('-'))}`] = construct;
 
 		if(waitingHTML[name] !== void 0)
 			checkWaiting(name, namespace);
@@ -106,11 +106,11 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 	}
 
 	self.html = function(name, outerHTML, namespace){
-		var scope = namespace || self;
-		var templatePath = false;
+		const scope = namespace || self;
+		let templatePath = false;
 
 		if(outerHTML.constructor === Object){
-			var template;
+			let template;
 
 			if(outerHTML.template){
 				templatePath = outerHTML.template;
@@ -128,7 +128,7 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 						TemplatePending.push(function(){
 							self.html(name, outerHTML, namespace, true);
 						});
-						return console.warn("Waiting template path '"+outerHTML.template+"' to be loaded");
+						return console.warn(`Waiting template path '${outerHTML.template}' to be loaded`);
 					}
 				}
 			}
@@ -140,20 +140,20 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 				TemplatePending.push(function(){
 					self.html(name, outerHTML, namespace, true);
 				});
-				return console.warn("Waiting template for '"+name+"' to be loaded");
+				return console.warn(`Waiting template for '${name}' to be loaded`);
 			}
 
 			outerHTML = template;
 		}
 
 		// 0=Function for scope, 1=DOM Contructor, 2=elements, 3=Template, 4=ModelRegex
-		var registrar = scope.registered[name];
+		let registrar = scope.registered[name];
 		if(registrar === void 0){
 			registrar = scope.registered[name] = new Array(5);
 			registrar[2] = [];
 		}
 
-		var temp;
+		let temp;
 		if(outerHTML.constructor === String)
 			temp = $.parseElement(outerHTML);
 		else temp = outerHTML;
@@ -161,9 +161,9 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 		if(temp.length === 1)
 			registrar[3] = temp[0];
 		else{
-			var tempDOM = document.createElement('div');
+			const tempDOM = document.createElement('div');
 			tempDOM.tempDOM = true;
-			for (var i = temp.length - 1; i >= 0; i--) {
+			for (let i = temp.length - 1; i >= 0; i--) {
 				tempDOM.insertBefore(temp[i], tempDOM.firstChild);
 			}
 			registrar[3] = tempDOM;
@@ -190,7 +190,7 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 		}
 	}
 
-	var tempDOM = document.createElement('div');
+	const tempDOM = document.createElement('div');
 	self.new = function(name, element, $item, namespace, asScope, _fromCheck){
 		if(internal.component.skip)
 			return;
@@ -203,12 +203,12 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 			return;
 		}
 
-		var scope = namespace || self;
+		const scope = namespace || self;
 
 		if(namespace !== void 0)
 			element.sf$space = namespace;
 
-		var registrar = scope.registered[name];
+		const registrar = scope.registered[name];
 		if(registrar === void 0 || element.childNodes.length === 0 && registrar[3] === void 0){
 			if(_fromCheck === true)
 				return;
@@ -216,13 +216,13 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 			if(waitingHTML[name] === void 0)
 				waitingHTML[name] = [];
 
-			waitingHTML[name].push({el:element, item:$item, namespace:namespace});
+			waitingHTML[name].push({el:element, item:$item, namespace});
 			return;
 		}
 
-		var avoid = /(^|:)(sf-|class|style)/;
-		var attr = element.attributes;
-		var inherit = internal.componentInherit[name];
+		const avoid = /(^|:)(sf-|class|style)/;
+		const attr = element.attributes;
+		const inherit = internal.componentInherit[name];
 
 		if(attr.length !== 0 && $item === void 0)
 			$item = {};
@@ -234,17 +234,17 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 			$item[attr[i].nodeName] = attr[i].value;
 		}
 
-		var newObj = (asScope ? $item : (
+		const newObj = (asScope ? $item : (
 			inherit !== void 0 ? new inherit() : {}
 		));
 
-		var index = 0;
+		let index = 0;
 		if(newObj.$el === void 0)
 			newObj.$el = $();
 		else index = newObj.$el.length;
 
 		if(index === 0){
-			var func = registrar[0];
+			const func = registrar[0];
 			if(func.constructor === Function){
 				if(inherit !== void 0 && asScope)
 					Object.setPrototypeOf(newObj, inherit.prototype);
@@ -268,19 +268,19 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 		if(registrar[4] === void 0)
 			registrar[4] = internal.model.createModelKeysRegex(element, newObj, null);
 
-		var forceConnectCall = false;
+		let forceConnectCall = false;
 		if(element.childNodes.length === 0){
-			var temp = registrar[3];
-			var tempDOM = temp.tempDOM;
+			let temp = registrar[3];
+			let { tempDOM } = temp;
 
 			// Create template here because we have the sample model
 			if(temp.constructor !== Object){
 				temp = prepareComponentTemplate(temp, tempDOM, name, newObj, registrar);
-				tempDOM = temp.tempDOM;
+				({ tempDOM } = temp);
 			}
 
 			// Create new object, but using registrar[3] as prototype
-			var copy = Object.create(temp);
+			const copy = Object.create(temp);
 
 			if(copy.parse.length !== 0){
 				copy.parse = copy.parse.slice(0);
@@ -305,7 +305,7 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 
 		// Custom component that written on the DOM
 		else{
-			var specialElement = {
+			const specialElement = {
 				repeat:[],
 				input:[]
 			};
@@ -347,10 +347,10 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 		constructor($item, namespace, asScope){
 			super();
 
-			var tagName = this.tagName.toLowerCase();
+			const tagName = this.tagName.toLowerCase();
 
 			if(internal.space.empty === false){
-				var haveSpace = namespace || this.closest('sf-space');
+				let haveSpace = namespace || this.closest('sf-space');
 				if(haveSpace !== null){
 					if(haveSpace.constructor === Space)
 						haveSpace = haveSpace.default;
@@ -403,15 +403,15 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 			if(this.model === void 0)
 				return;
 
-			var that = this;
-			var destroy = function(){
+			const that = this;
+			const destroy = function(){
 				if(that.model === void 0)
 					return;
 
 				if(that.model.$el.length !== 1){
-					var i = that.model.$el.indexOf(that);
+					const i = that.model.$el.indexOf(that);
 					if(i !== -1){
-						var temp = that.model.$el[i];
+						const temp = that.model.$el[i];
 						that.model.$el = that.model.$el.splice(i, 1);
 						that.model.destroyClone && that.model.destroyClone(temp);
 					}
@@ -441,13 +441,13 @@ function prepareComponentTemplate(temp, tempDOM, name, newObj, registrar){
 
 	// name = 'tag-name'
 	function defineComponent(name){
-		var have = customElements.get(name);
+		const have = customElements.get(name);
 		if(have) return have;
 
 		if(name.toLowerCase() !== name)
 			return console.error("Please use lower case when defining component name");
 
-		var len = name.length;
+		const len = name.length;
 		if(name.replace(/[^\w-]+/g, '').length !== len)
 			return console.error("Please use '-' and latin character when defining component tags");
 

--- a/src/sf-dom.js
+++ b/src/sf-dom.js
@@ -3,7 +3,7 @@ const IE11 = Object.getOwnPropertyDescriptor(Function.prototype, 'length').confi
 sf.dom = function(selector, context){
 	if(!selector){
 		if(selector === void 0){
-			var temp = sel=> temp.find(sel);
+			const temp = sel=> temp.find(sel);
 
 			if(IE11)
 				Object.defineProperty(temp, '_', {value:true});
@@ -285,7 +285,7 @@ class DOMList{
 					continue;
 				}
 
-				var evt;
+				let evt;
 				try {
 					evt = new window.CustomEvent(event, {detail: data, bubbles: true, cancelable: true});
 				} catch (e) {

--- a/src/sf-dom.js
+++ b/src/sf-dom.js
@@ -1,9 +1,9 @@
-var IE11 = Object.getOwnPropertyDescriptor(Function.prototype, 'length').configurable === false;
+const IE11 = Object.getOwnPropertyDescriptor(Function.prototype, 'length').configurable === false;
 
 sf.dom = function(selector, context){
 	if(!selector){
 		if(selector === void 0){
-			var temp = function(sel){return temp.find(sel)};
+			var temp = sel=> temp.find(sel);
 
 			if(IE11)
 				Object.defineProperty(temp, '_', {value:true});
@@ -31,8 +31,8 @@ sf.dom = function(selector, context){
 
 var $ = sf.dom; // Shortcut
 
-var css_str = /\-([a-z0-9])/;
-var css_strRep = function(f, m){return m.toUpperCase()};
+const css_str = /\-([a-z0-9])/;
+const css_strRep = (f, m)=> m.toUpperCase();
 class DOMList{
 	constructor(elements){
 		if(elements === null){
@@ -46,7 +46,7 @@ class DOMList{
 			return this;
 		}
 
-	    for (var i = 0; i < elements.length; i++)
+	    for (let i = 0; i < elements.length; i++)
 	    	this[i] = elements[i];
 
 		this.length = elements.length;
@@ -54,7 +54,7 @@ class DOMList{
 	}
 	push(el){
 		if(this._){
-			var news = recreateDOMList(this, this.length+1);
+			const news = recreateDOMList(this, this.length+1);
 			news[this.length] = el;
 
 			return news;
@@ -103,8 +103,8 @@ class DOMList{
 		if(this.length === 1) // Optimize perf ~66%
 			return _DOMList(this[0].querySelectorAll(selector));
 
-		var t = [];
-		for (var i = 0; i < this.length; i++)
+		const t = [];
+		for (let i = 0; i < this.length; i++)
 			t.push.apply(t, this[i].querySelectorAll(selector));
 		return _DOMList(t);
 	}
@@ -115,42 +115,42 @@ class DOMList{
 			return _DOMList(this[0].parentNode);
 		}
 
-		var t = [];
-		for (var i = 0; i < this.length; i++)
+		const t = [];
+		for (let i = 0; i < this.length; i++)
 			t.push.apply(t, this[i].closest(selector));
 		return _DOMList(t);
 	}
 	prev(selector){
-		var t;
+		let t;
 		if(this.length !== 0)
 			t = $.prevAll(this[0], selector, false, true);
 		return _DOMList(t || []);
 	}
 	prevAll(selector){
-		var t = [];
-		for (var i = 0; i < this.length; i++)
+		const t = [];
+		for (let i = 0; i < this.length; i++)
 			t.push.apply(t, $.prevAll(this[i], selector));
 		return _DOMList(t);
 	}
 	next(selector){
-		var t;
+		let t;
 		if(this.length !== 0)
 			t = $.prevAll(this[0], selector, true, true);
 		return _DOMList(t || []);
 	}
 	nextAll(selector){
-		var t = [];
-		for (var i = 0; i < this.length; i++)
+		const t = [];
+		for (let i = 0; i < this.length; i++)
 			t.push.apply(t, $.prevAll(this[i], selector, true));
 		return _DOMList(t);
 	}
 	children(selector){
-		var t = [];
+		const t = [];
 
-		for (var a = 0; a < this.length; a++) {
-			var child = this[a].children;
+		for (let a = 0; a < this.length; a++) {
+			const child = this[a].children;
 
-			for (var i = 0; i < child.length; i++){
+			for (let i = 0; i < child.length; i++){
 				if(child[i].matches(selector))
 					t.push(child[i]);
 			}
@@ -160,32 +160,32 @@ class DOMList{
 
 	// Action only
 	remove(){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].remove();
 		return this;
 	}
 	empty(){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].textContent = '';
 		return this;
 	}
 	addClass(name){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			DOMTokenList.prototype.add.apply(this[i].classList, name.split(' '));
 		return this;
 	}
 	removeClass(name){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			DOMTokenList.prototype.remove.apply(this[i].classList, name.split(' '));
 		return this;
 	}
 	toggleClass(name){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			DOMTokenList.prototype.toggle.apply(this[i].classList, name.split(' '));
 		return this;
 	}
 	hasClass(name){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			if(this[i].classList.contains(name))
 				return true;
 		return false;
@@ -194,7 +194,7 @@ class DOMList{
 		if(value === void 0)
 			return this.length !== 0 ? this[0][name] : '';
 
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i][name] = value;
 
 		return this;
@@ -203,13 +203,13 @@ class DOMList{
 		if(value === void 0)
 			return this.length !== 0 ? this[0].getAttribute(name) : '';
 
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].setAttribute(name, value);
 
 		return this;
 	}
 	removeAttr(name){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].removeAttribute(name);
 
 		return this;
@@ -219,7 +219,7 @@ class DOMList{
 			return this.length !== 0 ? this[0].style[name] : '';
 
 		if(name.constructor === Object){
-			for(var key in name){
+			for(let key in name){
 				if(key.includes('-') === false)
 					continue;
 
@@ -241,7 +241,7 @@ class DOMList{
 		return this;
 	}
 	on(event, selector, callback, options){
-		for (var i = 0; i < this.length; i++){
+		for (let i = 0; i < this.length; i++){
 			if(internal.model.specialEvent[event] !== void 0){
 				internal.model.specialEvent[event](this[i], null, callback);
 				continue;
@@ -253,15 +253,15 @@ class DOMList{
 		return this;
 	}
 	off(event, selector, callback, options){
-		for (var i = 0; i < this.length; i++){
+		for (let i = 0; i < this.length; i++){
 			if(event === void 0){
 				$.off(this[i]);
 				continue;
 			}
 
 			if(internal.model.specialEvent[event] !== void 0){
-				if(this[i]['sf$eventDestroy_'+event] !== void 0)
-					this[i]['sf$eventDestroy_'+event]();
+				if(this[i][`sf$eventDestroy_${event}`] !== void 0)
+					this[i][`sf$eventDestroy_${event}`]();
 
 				continue;
 			}
@@ -271,15 +271,15 @@ class DOMList{
 		return this;
 	}
 	once(event, selector, callback){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			$.once(this[i], event, selector, callback);
 		return this;
 	}
 	trigger(events, data, direct) {
 		events = events.split(' ');
-		for (var i = 0; i < events.length; i++) {
-			var event = events[i];
-			for (var j = 0; j < this.length; j++) {
+		for (let i = 0; i < events.length; i++) {
+			const event = events[i];
+			for (let j = 0; j < this.length; j++) {
 				if(direct === true){
 					this[j][event](data);
 					continue;
@@ -300,12 +300,12 @@ class DOMList{
 		return this;
 	}
 	animateKey(name, callback, duration){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			$.animateKey(this[i], name, callback, duration);
 		return this;
 	}
 	each(callback){
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			callback.call(this[i], i, this);
 		return this;
 	}
@@ -313,7 +313,7 @@ class DOMList{
 		if(value === void 0)
 			return this.length !== 0 && this[0].$data ? this[0].$data[key] : void 0;
 
-		for (var i = 0; i < this.length; i++){
+		for (let i = 0; i < this.length; i++){
 			if(this[i].$data === void 0)
 				this[i].$data = {};
 			this[i].$data[key] = value;
@@ -321,7 +321,7 @@ class DOMList{
 		return this;
 	}
 	removeData(key){
-		for (var i = 0; i < this.length; i++){
+		for (let i = 0; i < this.length; i++){
 			if(this[i].$data === void 0)
 				continue;
 
@@ -331,7 +331,7 @@ class DOMList{
 	}
 	append(element){
 		if(element.constructor === Array){
-			for (var i = 0; i < element.length; i++)
+			for (let i = 0; i < element.length; i++)
 				this[0].append(element[i]);
 		}
 		else{
@@ -343,7 +343,7 @@ class DOMList{
 	}
 	prepend(element){
 		if(element.constructor === Array){
-			for (var i = 0; i < element.length; i++)
+			for (let i = 0; i < element.length; i++)
 				this[0].prepend(element[i]);
 		}
 		else{
@@ -363,13 +363,13 @@ class DOMList{
 		return _DOMList(this.slice(i, count > 0 ? count : void 0));
 	}
 	insertAfter(el){
-		var parent = el.parentNode;
-		var next = el.nextSibling;
+		const parent = el.parentNode;
+		const next = el.nextSibling;
 		parent.insertBefore(this[0], next);
 
 		// Sometime it could gone
 		if(this[0] === void 0){
-			var temp = toArray(this);
+			const temp = toArray(this);
 			temp[0] = el.previousSibling;
 
 			for (var i = 1; i < temp.length; i++)
@@ -384,12 +384,12 @@ class DOMList{
 		return this;
 	}
 	insertBefore(el){
-		var parent = el.parentNode;
+		const parent = el.parentNode;
 		parent.insertBefore(this[0], el);
 
 		// Sometime it could gone
 		if(this[0] === void 0){
-			var temp = toArray(this);
+			const temp = toArray(this);
 			temp[0] = el.nextSibling;
 
 			for (var i = 1; i < temp.length; i++)
@@ -408,7 +408,7 @@ class DOMList{
 		if(text === void 0)
 			return this.length !== 0 ? this[0].textContent : '';
 
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].textContent = text;
 		return this;
 	}
@@ -416,7 +416,7 @@ class DOMList{
 		if(text === void 0)
 			return this.length !== 0 ? this[0].innerHTML : '';
 
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].innerHTML = text;
 		return this;
 	}
@@ -424,7 +424,7 @@ class DOMList{
 		if(text === void 0)
 			return this.length !== 0 ? this[0].value : '';
 
-		for (var i = 0; i < this.length; i++)
+		for (let i = 0; i < this.length; i++)
 			this[i].text = text;
 		return this;
 	}
@@ -458,38 +458,38 @@ function _DOMList(list){
 	if(!list || list.forEach === void 0 || list.constructor !== NodeList)
 		return new DOMList(list);
 
-	var length = list.length;
+	const { length } = list;
 	Object.setPrototypeOf(list, DOMList.prototype);
 	list.length = length;
 	return list;
 }
 
 function queryElements(arr, selector){
-	var list = [];
-	for (var i = 0; i < arr.length; i++)
+	const list = [];
+	for (let i = 0; i < arr.length; i++)
 		list.push.apply(list, arr[i].querySelectorAll(selector));
 	return list;
 }
 
 // Fix for IE11 and Safari, due to lack of writable length
 function recreateDOMList($el, length){
-	var args = ['sel'];
+	const args = ['sel'];
 	for (var i = 1; i < length; i++)
-		args.push('a'+i);
+		args.push(`a${i}`);
 
-	var obj = {};
-	var temp = Function('o', 'return function('+args.join(',')+'){return o.find(sel)}')(obj);
+	const obj = {};
+	const temp = Function('o', `return function(${args.join(',')}){return o.find(sel)}`)(obj);
 	for (var i = 0; i < length; i++)
 		temp[i] = $el[i];
 
-	obj.find = function(sel){return temp.find(sel)};
+	obj.find = sel=> temp.find(sel);
 
 	Object.defineProperty(temp, '_', {value:true});
 	return Object.setPrototypeOf(temp, DOMList.prototype);
 }
 
 ;(function(){
-	var self = sf.dom;
+	const self = sf.dom;
 
 	// ToDo: Optimize performance by using `length` check instead of `for` loop
 	self.fn = DOMList.prototype;
@@ -510,7 +510,7 @@ function recreateDOMList($el, length){
 	}
 
 	self.isChildOf = function(child, parent) {
-	     var node = child.parentNode;
+	     let node = child.parentNode;
 	     while (node !== null) {
 	         if(node === parent)
 	             return true;
@@ -532,8 +532,8 @@ function recreateDOMList($el, length){
 	}
 
 	self.prevAll = function(element, selector, isNext, one){
-		var result = [];
-		var findNodes = (!selector || selector.constructor !== String) ? true : false;
+		const result = [];
+		const findNodes = (!selector || selector.constructor !== String) ? true : false;
 
 		// Skip current element
 		element = isNext ? element.nextSibling : element.previousSibling;
@@ -566,9 +566,7 @@ function recreateDOMList($el, length){
 	}
 
 	// Shorcut
-	self.nextAll = function(element, selector, one){
-		return self.prevAll(element, selector, true, one);
-	}
+	self.nextAll = (element, selector, one)=> self.prevAll(element, selector, true, one)
 
 	/**
 	 * Listen to an event
@@ -582,14 +580,14 @@ function recreateDOMList($el, length){
 	self.on = function(element, event, selector, callback, options){
 		if(event.includes(' ')){
 			event = event.split(' ');
-			for (var i = 0; i < event.length; i++) {
+			for (let i = 0; i < event.length; i++) {
 				self.on(element, event[i], selector, callback, options);
 			}
 			return;
 		}
 
 		if(callback !== void 0 && callback.constructor === Object){
-			var temp = options;
+			const temp = options;
 			options = callback;
 			callback = temp;
 		}
@@ -607,9 +605,9 @@ function recreateDOMList($el, length){
 		if(selector){
 			// Check the related callback from `$0.sf$eventListener[event][index].callback`
 
-			var tempCallback = callback;
+			const tempCallback = callback;
 			callback = function(ev){
-				var target = ev.target.closest(selector);
+				const target = ev.target.closest(selector);
 				if(target !== null)
 					tempCallback.call(target, ev);
 			}
@@ -629,8 +627,8 @@ function recreateDOMList($el, length){
 
 			// Also listen for other window
 			windowEv[event].push(callback);
-			var winList = sf.window.list;
-			for(var key in winList){
+			const winList = sf.window.list;
+			for(let key in winList){
 				winList[key].addEventListener(event, callback, callback.options);
 				saveEvent(winList[key], event, callback);
 			}
@@ -698,7 +696,7 @@ function recreateDOMList($el, length){
 			if(windowEv[event] === void 0 || windowEv[event].length === 0)
 				return;
 
-			var list = windowEv[event];
+			const list = windowEv[event];
 			if(callback){
 				var i = list.indexOf(callback);
 				if(i !== -1)
@@ -710,8 +708,8 @@ function recreateDOMList($el, length){
 			removeEvent(window, event, selector, callback, options);
 
 			// Remove from other window
-			var winList = sf.window.list;
-			for(var key in winList)
+			const winList = sf.window.list;
+			for(let key in winList)
 				removeEvent(winList[key], event, selector, callback, options);
 
 			return;
@@ -746,12 +744,12 @@ function recreateDOMList($el, length){
 		else{
 			var ref = element.sf$eventListener;
 			if(ref !== void 0 && ref[event] !== void 0){
-				var ref2 = ref[event];
+				const ref2 = ref[event];
 				for (var i = ref2.length - 1; i >= 0; i--) {
 					if(selector && ref2[i].selector !== selector)
 						continue;
 
-					var options = ref2[i].options;
+					var { options } = ref2[i];
 					element.removeEventListener(event, ref2.splice(i, 1)[0], options);
 				}
 
@@ -780,7 +778,7 @@ function recreateDOMList($el, length){
 			element.offsetParent === null || window.getComputedStyle(element).visibility === 'hidden'
 		)) return;
 
-		var animationEnd = null;
+		let animationEnd = null;
 
 		if(element.style.animation !== void 0)
 			animationEnd = 'animationend';
@@ -788,16 +786,16 @@ function recreateDOMList($el, length){
 		if(element.style.WebkitAnimation !== void 0)
 			animationEnd = 'webkitAnimationEnd';
 
-	  	var style = element.style;
-		var arrange = animationName;
+	  	const { style } = element;
+		let arrange = animationName;
 
 		if(duration.duration !== void 0)
-			arrange += ' '+duration.duration+'s';
+			arrange += ` ${duration.duration}s`;
 		if(duration.ease !== void 0)
-			arrange += ' '+duration.ease;
+			arrange += ` ${duration.ease}`;
 
 		if(duration.delay !== void 0){
-			arrange += ' '+duration.delay+'s';
+			arrange += ` ${duration.delay}s`;
 
 			if(animationEnd === 'animationend')
 				var animationStart = 'animationstart';
@@ -822,11 +820,11 @@ function recreateDOMList($el, length){
 		else style.visibility = 'visible';
 
 		if(duration.iteration !== void 0)
-			arrange += ' '+duration.iteration;
+			arrange += ` ${duration.iteration}`;
 		if(duration.direction !== void 0)
-			arrange += ' '+duration.direction;
+			arrange += ` ${duration.direction}`;
 		if(duration.fill !== void 0)
-			arrange += ' '+duration.fill;
+			arrange += ` ${duration.fill}`;
 
 		style.webkitAnimation = style.animation = arrange;
 
@@ -839,8 +837,8 @@ function recreateDOMList($el, length){
 			element.classList.add('anim-element');
 
 			if(element.parentNode !== null){
-				var origin = (element.offsetLeft + element.offsetWidth/2)+'px' + (element.offsetTop + element.offsetHeight/2)+'px';
-				var parentStyle = element.parentNode.style;
+				const origin = (element.offsetLeft + element.offsetWidth/2)+'px' + (element.offsetTop + element.offsetHeight/2)+'px';
+				const parentStyle = element.parentNode.style;
 				element.parentNode.classList.add('anim-parent');
 				parentStyle.webkitPerspectiveOrigin = parentStyle.perspectiveOrigin = origin;
 			}
@@ -852,7 +850,7 @@ function recreateDOMList($el, length){
 						element.classList.remove('anim-element');
 						style.webkitAnimation = style.animation = '';
 
-						var parentStyle = element.parentNode.style;
+						const parentStyle = element.parentNode.style;
 						parentStyle.webkitPerspectiveOrigin = parentStyle.perspectiveOrigin = '';
 
 						if(callback !== void 0) callback.call(element);
@@ -862,9 +860,9 @@ function recreateDOMList($el, length){
 		});
 	}
 
-	var emptyDOM = document.createElement('div');
+	const emptyDOM = document.createElement('div');
 	self.parseElement = function(html, elementOnly){
-		emptyDOM.innerHTML = '<template>'+html+'</template>';
+		emptyDOM.innerHTML = `<template>${html}</template>`;
 
 		if(elementOnly)
 			return emptyDOM.firstElementChild.content.children || [];
@@ -872,7 +870,7 @@ function recreateDOMList($el, length){
 	}
 
 	self.escapeText = function(text){
-		var tempDOM = emptyDOM;
+		const tempDOM = emptyDOM;
 		tempDOM.textContent = text;
 		return tempDOM.innerHTML;
 	}
@@ -881,17 +879,17 @@ function recreateDOMList($el, length){
 		if(elements.remove !== void 0)
 			return elements.remove();
 
-		for (var i = 0; i < elements.length; i++) {
+		for (let i = 0; i < elements.length; i++) {
 			elements[i].remove();
 		}
 	}
 
-	var documentElement = null;
+	let documentElement = null;
 	sf.loader.domReady(function(){
 		documentElement = document.body.parentNode;
 	});
 
-	var haveSymbol = /[~`!@#$%^&*()+={}|[\]\\:";'<>?,./ ]/;
+	const haveSymbol = /[~`!@#$%^&*()+={}|[\]\\:";'<>?,./ ]/;
 	self.getSelector = function(element, childIndexes, untilElement){
 		if(untilElement === void 0) untilElement = documentElement;
 		else if(element === untilElement){
@@ -900,20 +898,20 @@ function recreateDOMList($el, length){
 			return '';
 		}
 
-		var previousSibling = childIndexes ? 'previousSibling' : 'previousElementSibling';
+		const previousSibling = childIndexes ? 'previousSibling' : 'previousElementSibling';
 
-		var names = [];
+		const names = [];
 		while(element.parentElement !== null){
 			if(!childIndexes && element.id && !haveSymbol.test(element.id)){
-				names.unshift('#'+element.id);
+				names.unshift(`#${element.id}`);
 				break;
 			}
 			else{
 				if(element === untilElement)
 					break;
 				else {
-					var e = element;
-					var i = childIndexes ? 0 : 1;
+					let e = element;
+					let i = childIndexes ? 0 : 1;
 
 					while(e[previousSibling]){
 						e = e[previousSibling];
@@ -923,7 +921,7 @@ function recreateDOMList($el, length){
 					if(childIndexes)
 						names.unshift(i);
 					else
-						names.unshift(":nth-child("+i+")");
+						names.unshift(`:nth-child(${i})`);
 				}
 
 				element = element.parentElement;
@@ -941,12 +939,12 @@ function recreateDOMList($el, length){
 		if(array.length === 0) // 2ms
 			return context;
 
-		var element = context || documentElement;
+		let element = context || documentElement;
 
 		if(array[0].constructor === String && element.id !== array[0].substr(1)) // 3.9ms
 			element = element.querySelector(array[0]);
 
-		for (var i = 0; i < array.length; i++) { // 36ms
+		for (let i = 0; i < array.length; i++) { // 36ms
 			element = array[i] === 0
 				? element.firstChild
 				: element.childNodes.item(array[i]); // 37ms

--- a/src/sf-events.js
+++ b/src/sf-events.js
@@ -70,7 +70,7 @@ sf.events = (function(){
 			if(self._listener[name] === void 0)
 				self._listener[name] = [];
 
-			var callback = self._listener[name];
+			const callback = self._listener[name];
 		}
 
 		defaultVal = null;

--- a/src/sf-events.js
+++ b/src/sf-events.js
@@ -4,7 +4,7 @@ sf.events = (function(){
 
 	function Events(name, defaultVal){
 		if(name.constructor === Array){
-			for (var i = 0; i < name.length; i++)
+			for (let i = 0; i < name.length; i++)
 				Events(name[i], defaultVal);
 
 			return;
@@ -17,10 +17,10 @@ sf.events = (function(){
 			if(Events[name] !== void 0 && Events[name] !== defaultVal)
 				console.warn("Events", name, "already has value:", Events[name]);
 
-			var trigger = function(){
-				var ref = self._statusTrigger[name];
+			const trigger = function(){
+				const ref = self._statusTrigger[name];
 				if(ref !== void 0){
-					for (var i = 0; i < ref.length; i++) {
+					for (let i = 0; i < ref.length; i++) {
 						try{
 							ref[i]();
 						} catch(e) {
@@ -34,12 +34,12 @@ sf.events = (function(){
 				}
 			}
 
-			var active = Events[name] || defaultVal;
+			let active = Events[name] || defaultVal;
 			Object.defineProperty(Events, name, {
 				enumerable:true,
 				configurable:true,
-				get:function(){return active},
-				set:function(val){
+				get(){return active},
+				set(val){
 					if(active === val)
 						return;
 
@@ -54,7 +54,7 @@ sf.events = (function(){
 		// Events.on (Listener)
 		else if(Events[name] === void 0){
 			Events[name] = function(){
-				for (var i = 0; i < callback.length; i++) {
+				for (let i = 0; i < callback.length; i++) {
 					try{
 						// .apply() is performant here
 						callback[i].apply(null, arguments);
@@ -102,7 +102,7 @@ sf.events = (function(){
 		if(self._listener[name] === void 0)
 			return self._listener[name].length = 0;
 
-		var i = self._listener[name].indexOf(callback);
+		const i = self._listener[name].indexOf(callback);
 		if(i === -1) return;
 		self._listener[name].splice(i, 1);
 	}

--- a/src/sf-hot-reload.js
+++ b/src/sf-hot-reload.js
@@ -1,12 +1,12 @@
 // Allow direct function replacement to accelerate development
 // Note: this feature will allocate more small memory and small slow down
-var hotReloadAll = false; // All model property
+let hotReloadAll = false; // All model property
 
-var proxyModel, proxySpace, proxyComponent, proxyTemplate, internalProp;
-var backupTemplate, backupCompTempl;
+let proxyModel, proxySpace, proxyComponent, proxyTemplate, internalProp;
+let backupTemplate, backupCompTempl;
 
 ;(function(){
-var gEval = routerEval;
+const gEval = routerEval;
 
 sf.hotReload = function(mode){
 	if(mode === 1)
@@ -36,7 +36,7 @@ sf.hotReload = function(mode){
 		// Register event
 		setTimeout(function(){
 			if(window.___browserSync___ !== void 0){
-				var socket = window.___browserSync___.socket;
+				const { socket } = window.___browserSync___;
 				socket.on('sf-hot-js', gEval);
 				socket.on('sf-hot-html', gEval);
 			}
@@ -47,10 +47,10 @@ sf.hotReload = function(mode){
 
 })();
 
-var haveLoaded = new WeakSet();
+const haveLoaded = new WeakSet();
 function reapplyScope(proxy, space, scope, func, forceHaveLoaded){
 	function refunction(prop, replacement){
-		var proxier = proxy[prop];
+		let proxier = proxy[prop];
 		if(proxier === void 0){
 			if(scope[prop] && scope[prop].ref !== void 0)
 				proxier = proxy[prop] = scope[prop];
@@ -64,7 +64,7 @@ function reapplyScope(proxy, space, scope, func, forceHaveLoaded){
 		if(proxier.protoFunc !== void 0)
 			proxier.ref = replacement || proxier.ref;
 		else{
-			var ref = (replacement || scope[prop]);
+			const ref = (replacement || scope[prop]);
 
 			if(proxier !== ref)
 				proxier.ref = ref;
@@ -75,7 +75,7 @@ function reapplyScope(proxy, space, scope, func, forceHaveLoaded){
 
 	// Keep component's original scope for first time only
 	if(func === void 0){
-		for(var prop in scope){
+		for(let prop in scope){
 			if(internalProp[prop] === true) // Skip function that related with framework
 				continue;
 
@@ -88,8 +88,8 @@ function reapplyScope(proxy, space, scope, func, forceHaveLoaded){
 	scope.hotReloading && scope.hotReloading(scope);
 
 	if(func.constructor === Function){
-		var enabled = true;
-		func(new Proxy(scope, {set:function(obj, prop, val){
+		let enabled = true;
+		func(new Proxy(scope, {set(obj, prop, val){
 			// Skip function that related with framework
 			// And skip if proxy is not enabled
 			if(enabled === false || internalProp[prop] === true){
@@ -116,8 +116,8 @@ function reapplyScope(proxy, space, scope, func, forceHaveLoaded){
 
 // On model scope reregistered
 function hotModel(space, name, func){
-	var scope = space(name);
-	var proxy = proxyModel.get(scope);
+	const scope = space(name);
+	let proxy = proxyModel.get(scope);
 
 	// If new model
 	if(proxy === void 0 || !scope){
@@ -130,7 +130,7 @@ function hotModel(space, name, func){
 
 // On new component created
 function hotComponentAdd(space, name, scope){
-	var proxy = proxySpace.get(space);
+	let proxy = proxySpace.get(space);
 
 	// If new space
 	if(proxy === void 0){
@@ -138,7 +138,7 @@ function hotComponentAdd(space, name, scope){
 		proxySpace.set(space, proxy);
 	}
 
-	var list = proxy[name];
+	let list = proxy[name];
 	if(list === void 0)
 		list = proxy[name] = [];
 
@@ -151,24 +151,24 @@ function hotComponentAdd(space, name, scope){
 }
 
 function hotComponentRemove(el){
-	var proxy = proxySpace.get(el.sf$space);
+	const proxy = proxySpace.get(el.sf$space);
 	if(proxy === void 0)
 		return;
 
-	var list = proxy[el.sf$controlled];
+	const list = proxy[el.sf$controlled];
 	list.splice(list.indexOf(el.model), 1);
 }
 
 // On component scope reregistered
 function hotComponentRefresh(space, name, func){
-	var list = proxySpace.get(space);
+	let list = proxySpace.get(space);
 	if(list === void 0 || list[name] === void 0)
 		return;
 
 	list = list[name];
 
-	for (var i = 0; i < list.length; i++){
-		var proxy = proxyComponent.get(list[i]);
+	for (let i = 0; i < list.length; i++){
+		let proxy = proxyComponent.get(list[i]);
 		if(proxy === void 0){
 			proxy = {};
 			proxyComponent.set(list[i], proxy);
@@ -184,23 +184,23 @@ function hotComponentRefresh(space, name, func){
 
 // Refresh views html and component
 function hotTemplate(templates){
-	var vList = sf.views.list;
-	var changes = {};
+	const vList = sf.views.list;
+	const changes = {};
 
-	for(var path in templates){
+	for(let path in templates){
 		if(backupTemplate[path] === void 0 || backupTemplate[path] === templates[path])
 			continue;
 
-		var forComp = proxyTemplate[path]; // [space, name]
+		const forComp = proxyTemplate[path]; // [space, name]
 		if(forComp !== void 0){
-			var _space = forComp[0];
-			var _name = forComp[1];
-			var registrar = _space.registered[_name];
+			const _space = forComp[0];
+			const _name = forComp[1];
+			const registrar = _space.registered[_name];
 
 			if(registrar !== void 0 && registrar[3] !== void 0){
-				var old = registrar[3].outerHTML;
+				const old = registrar[3].outerHTML;
 				sf.component.html(_name, {template:path}, _space);
-				var now = registrar[3].outerHTML;
+				const now = registrar[3].outerHTML;
 
 				if(now !== old
 				   || (backupCompTempl.has(registrar)
@@ -216,24 +216,24 @@ function hotTemplate(templates){
 		changes[path] = true;
 	}
 
-	for(var name in vList){
-		var routes = vList[name].routes;
-		var sfPageViews = $('sf-page-view', vList[name].rootDOM);
+	for(let name in vList){
+		const { routes } = vList[name];
+		const sfPageViews = $('sf-page-view', vList[name].rootDOM);
 
-		for (var i = 0; i < sfPageViews.length; i++) {
-			var page = sfPageViews[i];
-			var pageTemplate = page.sf$templatePath;
+		for (let i = 0; i < sfPageViews.length; i++) {
+			const page = sfPageViews[i];
+			const pageTemplate = page.sf$templatePath;
 			if(pageTemplate === void 0 || changes[pageTemplate] === void 0)
 				continue;
 
 			page.innerHTML = templates[pageTemplate];
 
-			page.routeCached.html = sf.dom.parseElement('<template>'+templates[pageTemplate]+'</template>', true)[0];
+			page.routeCached.html = sf.dom.parseElement(`<template>${templates[pageTemplate]}</template>`, true)[0];
 
 			// Replace with the old nested view
-			var nesteds = page.sf$viewSelector;
-			for(var nested in nesteds){
-				var el = page.querySelector(nested);
+			const nesteds = page.sf$viewSelector;
+			for(let nested in nesteds){
+				const el = page.querySelector(nested);
 				el.parentNode.replaceChild(nesteds[nested], el);
 			}
 		}
@@ -246,22 +246,22 @@ internal.hotTemplate = hotTemplate;
 
 // Refresh component html
 function hotComponentTemplate(scope, name){
-	var registrar = scope.registered[name];
-	var freezed = registrar[2].slice(0); // freeze to avoid infinity loop if have any nest
+	const registrar = scope.registered[name];
+	const freezed = registrar[2].slice(0); // freeze to avoid infinity loop if have any nest
 
-	for (var z = 0; z < freezed.length; z++) {
-		var model = freezed[z];
-		var els = model.$el;
+	for (let z = 0; z < freezed.length; z++) {
+		const model = freezed[z];
+		const els = model.$el;
 
-		for (var k = 0; k < els.length; k++) {
-			var element = els[k];
+		for (let k = 0; k < els.length; k++) {
+			const element = els[k];
 
 			// Don't refresh component that not declared with sf.component.html
 			if(element.sf$elementReferences === void 0)
 				continue;
 
-			var parentNode = element.parentNode;
-			var nextNode = element.nextSibling;
+			const { parentNode } = element;
+			const nextNode = element.nextSibling;
 
 			// Detach from DOM tree first
 			if(parentNode !== null)
@@ -271,22 +271,22 @@ function hotComponentTemplate(scope, name){
 			// Clear old DOM linker
 			internal.model.removeModelBinding(model);
 
-			var temp = registrar[3];
+			let temp = registrar[3];
 			if(registrar[3].constructor !== Object){
-				var tempDOM = temp.tempDOM;
+				var { tempDOM } = temp;
 
 				temp = prepareComponentTemplate(temp, tempDOM, name, model, registrar);
-				tempDOM = temp.tempDOM;
+				({ tempDOM } = temp);
 			}
 
 			// Create new object, but using registrar[3] as prototype
-			var copy = Object.create(temp);
+			const copy = Object.create(temp);
 
 			if(copy.parse.length !== 0){
 				copy.parse = copy.parse.slice(0);
 
 				// Deep copy the original properties to new object
-				for (var i = 0; i < copy.parse.length; i++) {
+				for (let i = 0; i < copy.parse.length; i++) {
 					copy.parse[i] = Object.create(copy.parse[i]);
 					copy.parse[i].data = [null, model];
 				}

--- a/src/sf-language.js
+++ b/src/sf-language.js
@@ -1,6 +1,6 @@
 ;(function(){
 
-var self = sf.lang = function(el){
+const self = sf.lang = function(el){
 	sf.lang.init(el);
 }
 
@@ -21,8 +21,8 @@ self.add = function(lang, obj){
 	if(pendingCallback.length === 0)
 		return;
 
-	var defaultLang = self.list[self.default];
-	for (var i = 0; i < pendingCallback.length; i++) {
+	const defaultLang = self.list[self.default];
+	for (let i = 0; i < pendingCallback.length; i++) {
 		if(pendingCallback[i].callbackOnly === void 0)
 			pendingCallback[i](diveObject(defaultLang, pendingCallback[i].path));
 		else
@@ -37,27 +37,27 @@ self.changeDefault = function(defaultLang){
 
 	// Maybe have create other window?
 	if(windowDestroyListener !== false && sf.window.list.length !== 0){
-		var windows = sf.window.list;
+		const windows = sf.window.list;
 
-		for (var i = 0; i < windows.length; i++)
+		for (let i = 0; i < windows.length; i++)
 			windows[i].sf.lang.changeDefault(defaultLang);
 	}
 
 	function forComponents(){
-		var registered = sf.component.registered;
-		for(var keys in registered){
+		const { registered } = sf.component;
+		for(let keys in registered){
 			if(registered[keys][3] !== void 0)
 				refreshTemplate(registered[keys]);
 		}
 	}
 
 	function forSpaceComponents(){
-		var list = sf.space.list;
+		const { list } = sf.space;
 
-		for(var name in list){
-			var registered = list[name].default.registered;
+		for(let name in list){
+			const { registered } = list[name].default;
 
-			for(var keys in registered){
+			for(let keys in registered){
 				if(registered[keys][3] !== void 0)
 					refreshTemplate(registered[keys]);
 			}
@@ -72,14 +72,14 @@ self.changeDefault = function(defaultLang){
 
 	self.init(document.body);
 
-	var wList = sf.window.list;
-	for(var key in wList)
+	const wList = sf.window.list;
+	for(let key in wList)
 		self.init(wList[key].document.body);
 }
 
-var interpolate_ = /{(.*?)}/;
+const interpolate_ = /{(.*?)}/;
 function interpolate(text, obj){
-	var once = false;
+	let once = false;
 	return text.replace(interpolate_, function(full, match){
 		if(once === false && (obj.constructor === String || obj.constructor === Number)){
 			once = true;
@@ -96,7 +96,7 @@ function interpolate(text, obj){
 	});
 }
 
-var waiting = false;
+let waiting = false;
 var pendingCallback = [];
 
 self.get = function(path, obj, callback){
@@ -141,7 +141,7 @@ function startRequest(){
 }
 
 function getSingle(path, obj, callback){
-	var value = diveObject(self.list[self.default], path);
+	let value = diveObject(self.list[self.default], path);
 	if(value !== void 0){
 		if(obj)
 			value = interpolate(value, obj);
@@ -166,12 +166,12 @@ function getSingle(path, obj, callback){
 }
 
 function getMany(paths, obj, callback){
-	var default_ = self.list[self.default];
-	var value = {};
-	var missing = [];
+	const default_ = self.list[self.default];
+	let value = {};
+	const missing = [];
 
 	for (var i = 0; i < paths.length; i++) {
-		var temp = diveObject(default_, paths[i]);
+		const temp = diveObject(default_, paths[i]);
 
 		if(temp)
 			value[paths[i]] = temp;
@@ -195,9 +195,9 @@ function getMany(paths, obj, callback){
 		diveObject(pending, missing[i], 1);
 	}
 
-	var callback_ = function(){
-		for (var i = 0; i < missing.length; i++) {
-			var temp = diveObject(default_, missing[i]);
+	const callback_ = function(){
+		for (let i = 0; i < missing.length; i++) {
+			const temp = diveObject(default_, missing[i]);
 
 			diveObject(value, missing[i], temp);
 		}
@@ -220,11 +220,11 @@ self.assign = function(model, keyPath, obj, callback){
 		obj = void 0;
 	}
 
-	var keys = Object.keys(keyPath);
-	var vals = Object.values(keyPath);
+	const keys = Object.keys(keyPath);
+	const vals = Object.values(keyPath);
 
 	getMany(vals, obj, function(values){
-		for (var i = 0; i < keys.length; i++) {
+		for (let i = 0; i < keys.length; i++) {
 			model[keys[i]] = diveObject(values, vals[i]);
 		}
 
@@ -234,7 +234,7 @@ self.assign = function(model, keyPath, obj, callback){
 }
 
 function diveFill(obj1, obj2){
-	for(var key in obj2){
+	for(let key in obj2){
 		if(obj1[key] === void 0)
 			obj1[key] = obj2[key];
 
@@ -244,13 +244,13 @@ function diveFill(obj1, obj2){
 }
 
 var pending = false;
-var pendingElement = [];
+const pendingElement = [];
 var activeRequest = false;
 
 self.onError = console.error;
 
 self.init = function(el){
-	var list = el.querySelectorAll('[sf-lang]');
+	const list = el.querySelectorAll('[sf-lang]');
 	if(list.length === 0)
 		return;
 
@@ -260,7 +260,7 @@ self.init = function(el){
 	refreshLang(list);
 
 	if(pending !== false && self.serverURL !== false){
-		var callback = function(){
+		const callback = function(){
 			pending = false;
 			refreshLang(pendingElement, true);
 		}
@@ -276,9 +276,9 @@ self.init = function(el){
 }
 
 function diveObject(obj, path, setValue){
-	var parts = path.split('.');
-	for (var i = 0, n = parts.length-1; i <= n; i++) {
-		var key = parts[i];
+	const parts = path.split('.');
+	for (let i = 0, n = parts.length-1; i <= n; i++) {
+		const key = parts[i];
 
 		if(setValue === void 0){ // get only
 	    	if(obj[key] === void 0)
@@ -316,14 +316,14 @@ internal.language.refreshLang = function(el){
 };
 
 function refreshLang(list, noPending){
-	var defaultLang = self.list[self.default];
-	var parentElement = new Set();
+	let defaultLang = self.list[self.default];
+	const parentElement = new Set();
 
 	if(defaultLang === void 0)
 		defaultLang = self.list[self.default] = {};
 
-	var checks = new WeakSet();
-	for (var i = list.length-1; i >= 0; i--) {
+	const checks = new WeakSet();
+	for (let i = list.length-1; i >= 0; i--) {
 		if((list[i].sf_lang === self.default && noPending === true) || list[i].hasAttribute('sf-lang-skip')){
 			list.splice(i, 1);
 			continue;
@@ -342,7 +342,7 @@ function refreshLang(list, noPending){
 			continue;
 		}
 		else{
-			var modelElement = sf(elem, true);
+			const modelElement = sf(elem, true);
 			if(modelElement !== null){
 				if(parentElement.has(modelElement))
 					continue;
@@ -360,8 +360,8 @@ function refreshLang(list, noPending){
 			}
 		}
 
-		var target = elem.getAttribute('sf-lang');
-		var value = diveObject(defaultLang, target);
+		const target = elem.getAttribute('sf-lang');
+		const value = diveObject(defaultLang, target);
 
 		if(value === void 0){
 		    if(noPending !== true){
@@ -387,13 +387,13 @@ function refreshLang(list, noPending){
 	if(parentElement.size === 0)
 		return;
 
-	var appliedElement = new WeakSet();
+	const appliedElement = new WeakSet();
 
 	// Reapply template (component)
 	for(var elem of parentElement){
 		elem.sf_lang = self.default;
 
-		var model = elem.model;
+		let { model } = elem;
 		if(model === void 0)
 			model = sf(elem);
 
@@ -413,17 +413,17 @@ function refreshLang(list, noPending){
 	}
 }
 
-var templateParser_regex_split = /{{%=[0-9]+%/g;
+const templateParser_regex_split = /{{%=[0-9]+%/g;
 function elementReferencesRefresh(elem){
-	var eRef = elem.sf$elementReferences;
-	var processed = false;
-	var template = eRef.template;
+	const eRef = elem.sf$elementReferences;
+	let processed = false;
+	const { template } = eRef;
 
 	if(eRef.parsed === void 0)
 		eRef.parsed = new Array(template.parse);
 
 	for (var i = eRef.length-1; i >= 0; i--) {
-		var elemRef = eRef[i];
+		const elemRef = eRef[i];
 		if(elemRef.textContent !== void 0){
 			var parent = elemRef.textContent.parentElement;
 
@@ -438,7 +438,7 @@ function elementReferencesRefresh(elem){
 		}
 		else continue;
 
-		var value = diveObject(self.list[self.default], key);
+		const value = diveObject(self.list[self.default], key);
 		if(value === void 0){
 			if(pending === false)
 				pending = {};
@@ -455,7 +455,7 @@ function elementReferencesRefresh(elem){
 			// Refresh it now
 			// ToDo: fix value that fail/undefined if it's from RepeatedList/Property
 			if(elemRef.ref.name === 'value'){
-				var refB = elemRef.ref;
+				const refB = elemRef.ref;
 				elemRef.attribute.value = internal.model.applyParseIndex(refB.value, refB.parse_index, eRef.parsed, template.parse);
 			}
 			continue;
@@ -481,16 +481,16 @@ function elementReferencesRefresh(elem){
 
 function assignSquareBracket(value, elem, template, eRef){
 	value = value.replace(/%\*&/g, '-');
-	var tags = {};
+	const tags = {};
 
-	var squares = [];
+	const squares = [];
 	value = value.replace(/\[([a-zA-Z0-9\-]+):(.*?)\]/g, function(full, tag, match){
 		squares.push({tag:tag.toUpperCase(), val:match});
 		return '%*&';
 	}).split('%*&');
 
-	var childNodes = elem.childNodes;
-	var backup = {};
+	const { childNodes } = elem;
+	const backup = {};
 	for(var a=0, n=childNodes.length; a<n; a++){
 		var place, elemBackup = childNodes[a];
 		if(elemBackup.nodeType === 3){
@@ -508,14 +508,14 @@ function assignSquareBracket(value, elem, template, eRef){
 		place.push(elemBackup);
 	}
 
-	var found = template && true;
+	let found = template && true;
 	elem.textContent = value[0];
 
 	if(elem.firstChild !== null)
 		found = found && elementRebinding(template, eRef, elem.firstChild, elem);
 
 	for (var a = 1; a < value.length; a++) {
-		var square = squares[a-1];
+		const square = squares[a-1];
 		var elemBackup = backup[square.tag];
 		if(elemBackup === void 0 || elemBackup.length === 0)
 			elemBackup = document.createElement(square.tag);
@@ -546,8 +546,8 @@ function assignSquareBracket(value, elem, template, eRef){
 }
 
 function createParseIndex(text, remakeRef, template){
-	var parse_index = []
-	var value = text.replace(/{(.*?)}/g, function(full, match){
+	const parse_index = []
+	const value = text.replace(/{(.*?)}/g, function(full, match){
 		if(isNaN(match) !== false){
 			if(template.modelRefRoot[match] !== void 0)
 				match = template.modelRefRoot[match][0];
@@ -555,7 +555,7 @@ function createParseIndex(text, remakeRef, template){
 			else if(template.modelRef !== void 0 && template.modelRef[match] !== void 0)
 				match = template.modelRef[match][0];
 			else{
-				console.error("Language can't find existing model binding for '"+match+"' from", Object.keys(template.modelRefRoot), template);
+				console.error(`Language can't find existing model binding for '${match}' from`, Object.keys(template.modelRefRoot), template);
 				return '';
 			}
 		}
@@ -574,7 +574,7 @@ function createParseIndex(text, remakeRef, template){
 }
 
 function elementRebinding(template, eRef, elem, parentNode){
-	var remake = {
+	const remake = {
 		textContent:elem,
 		ref:{
 			address:$.getSelector(elem, true, parentNode),
@@ -589,29 +589,29 @@ function elementRebinding(template, eRef, elem, parentNode){
 }
 
 function refreshTemplate(elemRef){
-	var collections = elemRef[2];
-	var template = elemRef[3];
+	const collections = elemRef[2];
+	const template = elemRef[3];
 
-	var addresses = template.addresses;
+	const { addresses } = template;
 	if(addresses === void 0)
 		return;
 
-	var found = false;
-	for (var i = addresses.length-1; i >= 0; i--) {
+	let found = false;
+	for (let i = addresses.length-1; i >= 0; i--) {
 		if(addresses[i].skipSFLang || addresses[i].value === void 0)
 			continue;
 
-		var elem = $.childIndexes(addresses[i].address, template.html).parentNode;
+		const elem = $.childIndexes(addresses[i].address, template.html).parentNode;
 		if(elem.hasAttribute('sf-lang') === false)
 			continue;
 
 		found = true;
 
-		var value = diveObject(self.list[self.default], elem.getAttribute('sf-lang'));
+		const value = diveObject(self.list[self.default], elem.getAttribute('sf-lang'));
 		if(value === void 0){
 			console.error(`Can't found '${elem.getAttribute('sf-lang')}' for ${self.default}, in`, self.list[self.default], ", maybe the language wasn't fully loaded");
 
-			var callback_ = function(){
+			const callback_ = function(){
 				refreshTemplate(elemRef);
 			};
 
@@ -622,11 +622,11 @@ function refreshTemplate(elemRef){
 
 		addresses.splice(i, 1);
 
-		var eRef = [];
+		const eRef = [];
 		assignSquareBracket(value, elem, template, eRef);
 
-		for (var a = 0; a < eRef.length; a++){
-			var ref = eRef[a].ref;
+		for (let a = 0; a < eRef.length; a++){
+			const { ref } = eRef[a];
 			ref.address = $.getSelector($.childIndexes(ref.address, elem), true, template.html);
 			addresses.push(ref);
 		}

--- a/src/sf-loader.js
+++ b/src/sf-loader.js
@@ -1,14 +1,14 @@
 sf.loader = new function(){
-	var self = this;
+	const self = this;
 	self.loadedContent = 0;
 	self.totalContent = 0;
 	self.DOMWasLoaded = false;
 	self.DOMReady = false;
 	self.turnedOff = true;
 
-	var whenDOMReady = [];
-	var whenDOMLoaded = [];
-	var whenProgress = [];
+	let whenDOMReady = [];
+	let whenDOMLoaded = [];
+	let whenProgress = [];
 
 	// Make event listener
 	self.onFinish = function(func){
@@ -33,7 +33,7 @@ sf.loader = new function(){
 	    ev.target.removeEventListener('load', self.f, {once:true});
 	    ev.target.removeEventListener('error', self.f, {once:true});
 
-		for (var i = 0; i < whenProgress.length; i++)
+		for (let i = 0; i < whenProgress.length; i++)
 			whenProgress[i](self.loadedContent, self.totalContent);
 	}
 
@@ -41,7 +41,7 @@ sf.loader = new function(){
 		if(self.DOMWasLoaded){
 			// check if some list was loaded
 			for (var i = list.length - 1; i >= 0; i--) {
-				if(document.querySelectorAll('link[href*="'+list[i]+'"]').length !== 0)
+				if(document.querySelectorAll(`link[href*="${list[i]}"]`).length !== 0)
 					list.splice(i, 1);
 			}
 			if(list.length === 0) return;
@@ -50,7 +50,7 @@ sf.loader = new function(){
 
 		self.totalContent = self.totalContent + list.length;
 		for(var i = 0; i < list.length; i++){
-			var s = document.createElement('link');
+			const s = document.createElement('link');
 	        s.rel = 'stylesheet';
 	        s.href = list[i];
 	        s.addEventListener('load', self.f, {once:true});
@@ -63,7 +63,7 @@ sf.loader = new function(){
 		if(self.DOMWasLoaded){
 			// check if some list was loaded
 			for (var i = list.length - 1; i >= 0; i--) {
-				if(document.querySelectorAll('script[src*="'+list[i]+'"]').length !== 0)
+				if(document.querySelectorAll(`script[src*="${list[i]}"]`).length !== 0)
 					list.splice(i, 1);
 			}
 			if(list.length === 0) return;
@@ -72,7 +72,7 @@ sf.loader = new function(){
 
 		self.totalContent = self.totalContent + list.length;
 		for(var i = 0; i < list.length; i++){
-			var s = document.createElement('script');
+			const s = document.createElement('script');
 	        s.type = "text/javascript";
 	        if(async) s.async = true;
 	        s.src = list[i];
@@ -82,7 +82,7 @@ sf.loader = new function(){
 		}
 	}
 
-	var lastState = '';
+	let lastState = '';
 	self.waitImages = function(){
 		lastState = 'loading';
 	}
@@ -93,8 +93,8 @@ sf.loader = new function(){
 			document.removeEventListener('load', domLoadEvent, true);
 
 			if(lastState === 'loading'){ // Find images
-				var temp = document.body.querySelectorAll('img:not(onload)[src]');
-				for (var i = 0; i < temp.length; i++) {
+				const temp = document.body.querySelectorAll('img:not(onload)[src]');
+				for (let i = 0; i < temp.length; i++) {
 					self.totalContent++;
 					temp[i].addEventListener('load', self.f, {once:true});
 					temp[i].addEventListener('error', self.f, {once:true});
@@ -109,7 +109,7 @@ sf.loader = new function(){
 		if(document.readyState === 'interactive' || document.readyState === 'complete'){
 			if(self.DOMReady === false){
 				self.DOMReady = true;
-				for (var i = 0; i < whenDOMReady.length; i++) {
+				for (let i = 0; i < whenDOMReady.length; i++) {
 					try{
 						whenDOMReady[i]();
 					} catch(e) {
@@ -142,7 +142,7 @@ sf.loader = new function(){
 
 		clearInterval(resourceWaitTimer);
 
-		var listener = document.querySelectorAll('script, link, img');
+		const listener = document.querySelectorAll('script, link, img');
 		for (var i = 0; i < listener.length; i++) {
 			listener[i].removeEventListener('error', self.f);
 			listener[i].removeEventListener('load', self.f);

--- a/src/sf-model.js
+++ b/src/sf-model.js
@@ -7,7 +7,7 @@ sf.model = function(name, options, func, namespace){
 	if((namespace || sf.component).registered[name] !== void 0)
 		return (namespace || root_)(name);
 
-	var scope = namespace || sf.model;
+	const scope = namespace || sf.model;
 	if(scope.root[name] === void 0){
 		if(internal.modelInherit[name] !== void 0)
 			scope.root[name] = new internal.modelInherit[name]();
@@ -30,7 +30,7 @@ function findBindListElement(el){
 }
 
 ;(function(){
-	var self = sf.model;
+	const self = sf.model;
 	self.root = {};
 	internal.modelPending = {};
 	internal.modelInherit = {};
@@ -43,9 +43,9 @@ function findBindListElement(el){
 		if(element === null)
 			return -1;
 
-		var i = -1;
-		var tagName = element.tagName;
-		var currentElement = element;
+		let i = -1;
+		const tagName = element.tagName;
+		const currentElement = element;
 
 		while(element !== null) {
 			if(element.tagName === tagName)
@@ -55,9 +55,9 @@ function findBindListElement(el){
 			element = element.previousSibling;
 		}
 
-		var ref = currentElement.sf$elementReferences && currentElement.sf$elementReferences.template.bindList;
+		const ref = currentElement.sf$elementReferences && currentElement.sf$elementReferences.template.bindList;
 
-		var VSM = currentElement.parentNode.$VSM;
+		const VSM = currentElement.parentNode.$VSM;
 		if(VSM !== void 0) return i + VSM.firstCursor;
 		return i;
 	}
@@ -75,9 +75,9 @@ function findBindListElement(el){
 		}
 		else internal.modelInherit[name] = options.extend;
 
-		var scope = namespace || self;
+		const scope = namespace || self;
 
-		var scopeTemp;
+		let scopeTemp;
 		if(hotReload)
 			hotModel(scope, name, func);
 		else{
@@ -89,8 +89,8 @@ function findBindListElement(el){
 		}
 
 		if(sf.loader.DOMWasLoaded && internal.modelPending[name] !== void 0){
-			var temp = internal.modelPending[name];
-			for (var i = 0; i < temp.length; i++) {
+			const temp = internal.modelPending[name];
+			for (let i = 0; i < temp.length; i++) {
 				sf.model.init(temp[i], temp[i].getAttribute('name'));
 			}
 
@@ -117,7 +117,7 @@ function findBindListElement(el){
 			getPrototypeMethods(keys, modelRef.constructor);
 
 			if(toString){
-				var temp = '';
+				let temp = '';
 				for(var key of keys){
 					if(temp.length === 0){
 						temp += key;
@@ -166,14 +166,14 @@ class SFModel extends HTMLElement {
 
 		delete this.sf$firstInit;
 		if(internal.space.empty === false){
-			var haveSpace = this.closest('sf-space');
+			const haveSpace = this.closest('sf-space');
 			if(haveSpace !== null){
 				internal.space.initModel(haveSpace, this);
 				return;
 			}
 		}
 
-		var name = this.getAttribute('name');
+		const name = this.getAttribute('name');
 
 		// Instant run when model scope was found or have loaded
 		if(sf.model.root[name] !== void 0 && internal.modelPending[name] === void 0){
@@ -183,7 +183,7 @@ class SFModel extends HTMLElement {
 				return sf.model.init(this, name);
 			}
 
-			var that = this;
+			const that = this;
 			sf.loader.onFinish(function(){
 				internal.language.refreshLang(that);
 				sf.model.init(that, name);
@@ -198,16 +198,16 @@ class SFModel extends HTMLElement {
 		internal.modelPending[name].push(this);
 	}
 	disconnectedCallback(){
-		var that = this;
-		var destroy = function(){
+		const that = this;
+		const destroy = function(){
 			if(that.model === void 0)
 				return;
 
 			if(that.model.$el){
-				var i = that.model.$el.indexOf(that);
+				const i = that.model.$el.indexOf(that);
 				if(i !== -1){
 					var model = that.model;
-					var temp = model.$el[i];
+					const temp = model.$el[i];
 
 					model.$el = model.$el.splice(i, 1);
 					model.destroy && model.destroy(temp, model.$el.length === 0);
@@ -215,7 +215,7 @@ class SFModel extends HTMLElement {
 			}
 
 			internal.model.removeModelBinding(that.model);
-		}
+		};
 
 		if(window.destroying)
 			return destroy();
@@ -231,7 +231,7 @@ var root_ = function(scope){
 		return sf.component(scope);
 
 	if(sf.model.root[scope] === void 0)
-		var scope_ = sf.model.root[scope] = {};
+		const scope_ = sf.model.root[scope] = {};
 
 	return sf.model.root[scope];
 }

--- a/src/sf-model.js
+++ b/src/sf-model.js
@@ -230,8 +230,9 @@ var root_ = function(scope){
 	if(sf.component.registered[scope])
 		return sf.component(scope);
 
-	if(sf.model.root[scope] === void 0)
-		const scope_ = sf.model.root[scope] = {};
+	if(sf.model.root[scope] === void 0) {
+		sf.model.root[scope] = {};
+	}
 
 	return sf.model.root[scope];
 }

--- a/src/sf-model/element-bind.js
+++ b/src/sf-model/element-bind.js
@@ -5,10 +5,10 @@ internal.model.removeModelBinding = function(ref, isDeep){
 	if(window.sf$proxy !== void 0)
 		return window.sf$proxy.removeModelBinding(ref, isDeep);
 
-	var bindedKey = ref.sf$bindedKey;
-	for(var key in bindedKey){
+	const bindedKey = ref.sf$bindedKey;
+	for(let key in bindedKey){
 		if(ref[key] !== void 0 && (ref[key].constructor === RepeatedProperty || ref[key].constructor === RepeatedList)){
-			var obj = ref[key];
+			const obj = ref[key];
 
 			// Deep remove for repeated element, only if it's object data type (primitive don't have sf$bindedKey)
 			if(obj.constructor === RepeatedList){
@@ -19,7 +19,7 @@ internal.model.removeModelBinding = function(ref, isDeep){
 				}
 			}
 			else{
-				for(var rp in obj){
+				for(let rp in obj){
 					if(typeof obj[rp] === 'object')
 						internal.model.removeModelBinding(obj[rp]);
 					else break;
@@ -28,7 +28,7 @@ internal.model.removeModelBinding = function(ref, isDeep){
 
 			// Clean ElementManipulator first
 			if(obj.$EM.constructor === ElementManipulatorProxy){
-				var list = obj.$EM.list;
+				const { list } = obj.$EM;
 				for (var i = list.length-1; i >= 0; i--) {
 					if(list[i].parentNode.isConnected === false){
 						if(!list[i].isComponent)
@@ -66,7 +66,7 @@ internal.model.removeModelBinding = function(ref, isDeep){
 
 			// Reset object proxies
 			Object.setPrototypeOf(obj, Object.prototype);
-			for(var objKey in obj){
+			for(let objKey in obj){
 				var temp = obj[objKey];
 				delete obj[objKey];
 				obj[objKey] = temp;
@@ -75,7 +75,7 @@ internal.model.removeModelBinding = function(ref, isDeep){
 			continue;
 		}
 
-		var bindRef = bindedKey[key];
+		const bindRef = bindedKey[key];
 		for (var i = bindRef.length-1; i >= 0; i--) {
 			if(bindRef[i].constructor === Function)
 				continue;
@@ -114,9 +114,9 @@ internal.model.removeModelBinding = function(ref, isDeep){
 	if(isDeep !== void 0 || ref.sf$internal === void 0)
 		return;
 
-	var deep = ref.sf$internal.deepBinding;
-	for(var path in deep){
-		var model = deepProperty(ref, path.split('%$'));
+	const deep = ref.sf$internal.deepBinding;
+	for(let path in deep){
+		const model = deepProperty(ref, path.split('%$'));
 		if(model !== void 0)
 			internal.model.removeModelBinding(model, true);
 	}
@@ -130,13 +130,13 @@ function repeatedRemoveDeepBinding(obj, refPaths){
 	if(refPaths.length === 0)
 		return;
 
-	that:for (var a = 0; a < refPaths.length; a++) {
+	that:for (let a = 0; a < refPaths.length; a++) {
 		if(refPaths[a].length === 1)
 			continue;
 
-		var ref = refPaths[a].slice(0, -1);
+		const ref = refPaths[a].slice(0, -1);
 		if(obj.constructor === RepeatedList){
-			for (var i = 0; i < obj.length; i++) {
+			for (let i = 0; i < obj.length; i++) {
 				var deep = deepProperty(obj[i], ref);
 				if(deep === void 0)
 					continue;
@@ -146,7 +146,7 @@ function repeatedRemoveDeepBinding(obj, refPaths){
 			continue that;
 		}
 
-		for(var key in obj){
+		for(let key in obj){
 			var deep = deepProperty(obj[key], ref);
 			if(deep === void 0)
 				continue;
@@ -157,20 +157,20 @@ function repeatedRemoveDeepBinding(obj, refPaths){
 }
 
 function modelToViewBinding(model, propertyName, callback, elementBind, type){
-	var originalModel = model;
-	var originalPropertyName = propertyName;
+	const originalModel = model;
+	let originalPropertyName = propertyName;
 
 	// Dive to the last object, create if not exist
 	if(propertyName.constructor === Array){
 		if(propertyName.length === 1)
 			propertyName = propertyName[0];
 		else{
-			var deep = deepProperty(model, propertyName.slice(0, -1));
+			const deep = deepProperty(model, propertyName.slice(0, -1));
 			if(deep === void 0)
 				return;
 
 			// Register every path as fixed object (where any property replacement will being assigned)
-			for (var i = 0, n = propertyName.length-1; i < n; i++) {
+			for (let i = 0, n = propertyName.length-1; i < n; i++) {
 				let value = model[propertyName[i]];
 
 				// Return if this not an object
@@ -181,10 +181,10 @@ function modelToViewBinding(model, propertyName, callback, elementBind, type){
 					Object.defineProperty(model, propertyName[i], {
 						enumerable: true,
 						configurable: true,
-						get:function(){
+						get(){
 							return value;
 						},
-						set:function(val){
+						set(val){
 							Object.assign(value, val);
 							return val;
 						}
@@ -206,7 +206,7 @@ function modelToViewBinding(model, propertyName, callback, elementBind, type){
 	if(model.sf$bindedKey === void 0)
 		initBindingInformation(model);
 
-	var bindedKey = model.sf$bindedKey;
+	let bindedKey = model.sf$bindedKey;
 
 	if(bindedKey[propertyName] !== void 0){
 		var ref = bindedKey[propertyName];
@@ -233,7 +233,7 @@ function modelToViewBinding(model, propertyName, callback, elementBind, type){
 	}
 
 	// Proxy property
-	var desc = Object.getOwnPropertyDescriptor(model, propertyName);
+	const desc = Object.getOwnPropertyDescriptor(model, propertyName);
 	if(desc === void 0 || desc.set !== void 0)
 		return;
 
@@ -245,34 +245,34 @@ function modelToViewBinding(model, propertyName, callback, elementBind, type){
 		originalPropertyName = stringifyPropertyPath(originalPropertyName);
 	}
 
-	var objValue = model[propertyName]; // Object value
+	let objValue = model[propertyName]; // Object value
 	if(objValue === void 0 || objValue === null)
 		objValue = '';
 
-	var _on = model['on$'+propertyName]; // Everytime value's going changed, callback value will assigned as new value
-	var _m2v = model['m2v$'+propertyName]; // Everytime value changed from script (not from View), callback value will only affect View
+	let _on = model[`on$${propertyName}`]; // Everytime value's going changed, callback value will assigned as new value
+	let _m2v = model[`m2v$${propertyName}`]; // Everytime value changed from script (not from View), callback value will only affect View
 
 	if(_on)
-		Object.defineProperty(model, 'on$'+propertyName, {
-			set:function(val){_on = val},
-			get:function(){return _on}
+		Object.defineProperty(model, `on$${propertyName}`, {
+			set(val){_on = val},
+			get(){return _on}
 		});
 
 	if(_m2v)
-		Object.defineProperty(model, 'm2v$'+propertyName, {
-			set:function(val){_m2v = val},
-			get:function(){return _on}
+		Object.defineProperty(model, `m2v$${propertyName}`, {
+			set(val){_m2v = val},
+			get(){return _on}
 		});
 
 	Object.defineProperty(model, propertyName, {
 		enumerable: true,
 		configurable: true,
-		get:function(){
+		get(){
 			return objValue;
 		},
-		set:function(val){
+		set(val){
 			if(objValue !== val){
-				var newValue, noFeedback, temp;
+				let newValue, noFeedback, temp;
 				if(inputBoundRunning === false){
 					if(_m2v !== void 0){
 						newValue = _m2v.call(model, val);
@@ -287,7 +287,7 @@ function modelToViewBinding(model, propertyName, callback, elementBind, type){
 
 				objValue = newValue !== void 0 ? newValue : val;
 
-				for (var i = 0; i < bindedKey.length; i++) {
+				for (let i = 0; i < bindedKey.length; i++) {
 					temp = bindedKey[i];
 					if(temp.inputBoundRun){
 						temp(objValue, bindedKey.input);
@@ -320,7 +320,7 @@ self.bindElement = function(element, modelScope, template, localModel, modelKeys
 		delete template.addresses;
 
 		if(element.parentNode !== null){
-			var newElem = template.html;
+			const newElem = template.html;
 			if(element.tagName.includes('-')){
 				newElem.sf$componentIgnore = true;
 				element.sf$componentIgnore = true;
@@ -335,11 +335,11 @@ self.bindElement = function(element, modelScope, template, localModel, modelKeys
 	}
 
 	// modelRefRoot_path index is not related with modelRefRoot property/key position
-	var properties = template.modelRefRoot_path;
+	let properties = template.modelRefRoot_path;
 	for (var i = 0; i < properties.length; i++) {
 		modelToViewBinding(modelScope, properties[i], {
-			element:element,
-			template:template
+			element,
+			template
 		});
 	}
 
@@ -353,8 +353,8 @@ self.bindElement = function(element, modelScope, template, localModel, modelKeys
 		properties = template.modelRef_path;
 		for (var i = 0; i < properties.length; i++) {
 			modelToViewBinding(localModel, properties[i], {
-				element:element,
-				template:template
+				element,
+				template
 			});
 		}
 	}

--- a/src/sf-model/event-handler.js
+++ b/src/sf-model/event-handler.js
@@ -1,33 +1,31 @@
-var rejectUntrusted = false;
+let rejectUntrusted = false;
 sf.security = function(level){
 	if(level & 1) rejectUntrusted = true;
 }
 
 function eventHandler(that, data, _modelScope, rootHandler, template){
-	var modelKeys = sf.model.modelKeys(_modelScope, true);
+	const modelKeys = sf.model.modelKeys(_modelScope, true);
 
-	var direct = false;
-	var script = data.value;
+	let direct = false;
+	let script = data.value;
 	script = avoidQuotes(script, function(script_){
 		if(sfRegex.anyOperation.test(script_) === false)
 			direct = true;
 
 		// Replace variable to refer to current scope
-		return script_.replace(template.modelRefRoot_regex, function(full, before, matched){
-			return before+'_modelScope.'+matched;
-		});
+		return script_.replace(template.modelRefRoot_regex, (full, before, matched)=> before+'_modelScope.'+matched);
 	});
 
-	var name_ = data.name.slice(1);
+	const name_ = data.name.slice(1);
 
 	// Create custom listener for repeated element
 	if(rootHandler){
-		var elementIndex = $.getSelector(that, true, rootHandler); // `rootHandler` may not the parent of `that`
+		const elementIndex = $.getSelector(that, true, rootHandler); // `rootHandler` may not the parent of `that`
 
 		if(rootHandler.sf$listListener === void 0)
 			rootHandler.sf$listListener = {};
 
-		var withKey = false;
+		let withKey = false;
 		if(template.uniqPattern !== void 0)
 			withKey = true;
 
@@ -40,7 +38,7 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 				var func = new Function('event', '_model_', '_modelScope', script);
 		}
 
-		var listener = rootHandler.sf$listListener[name_];
+		let listener = rootHandler.sf$listListener[name_];
 		if(listener === void 0){
 			listener = rootHandler.sf$listListener[name_] = [[elementIndex, func]];
 			listener.set = new Set([elementIndex.join('')]);
@@ -53,11 +51,11 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 			return;
 		}
 
-		var found = null;
-		var findEventFromList = function(arr){
+		let found = null;
+		const findEventFromList = function(arr){
 			// Partial array compare ([0,1,2] with [0,1,2,3,4] ==> true)
-			parent:for (var i = 0; i < listener.length; i++) {
-				var ref = listener[i];
+			parent:for (let i = 0; i < listener.length; i++) {
+				const ref = listener[i];
 				if(arr === void 0){
 					if(ref[0].length !== 0)
 						continue;
@@ -66,8 +64,8 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 					return ref[1];
 				}
 
-				var ref2 = ref[0];
-				for (var z = 0; z < ref2.length; z++) {
+				const ref2 = ref[0];
+				for (let z = 0; z < ref2.length; z++) {
 					if(ref2[z] !== arr[z])
 						continue parent;
 				}
@@ -81,12 +79,12 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 
 		// We need to get element with 'sf-bind-list' and check current element before processing
 		script = function(event){
-			var elem = event.target;
+			const elem = event.target;
 			if(elem === rootHandler)
 				return;
 
 			if(!elem.sf$elementReferences || !elem.sf$elementReferences.template.bindList){
-				var realThat = findBindListElement(elem);
+				const realThat = findBindListElement(elem);
 				if(realThat === null)
 					return;
 
@@ -110,14 +108,14 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 	// Wrap into a function, var event = firefox compatibility
 	else script = (new Function('_modelScope', 'event', script)).bind(that, _modelScope);
 
-	var containSingleChar = false;
-	var keys = name_.split('.');
-	var eventName = keys.shift();
+	let containSingleChar = false;
+	let keys = name_.split('.');
+	let eventName = keys.shift();
 
 	if(eventName === 'unfocus')
 		eventName = 'blur';
 
-	for (var i = keys.length - 1; i >= 0; i--) {
+	for (let i = keys.length - 1; i >= 0; i--) {
 		if(keys[i].length === 1){
 			containSingleChar = true;
 			break;
@@ -128,7 +126,7 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 	if(rejectUntrusted)
 		keys.add('trusted');
 
-	var options = {};
+	const options = {};
 	if(keys.has('once')){
 		options.once = true;
 		keys.delete('once');
@@ -160,14 +158,14 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 		return;
 	}
 
-	var pointerCode = 0;
+	let pointerCode = 0;
 	if(keys.has('left')){ pointerCode |= 1; keys.delete('left'); }
 	if(keys.has('middle')){ pointerCode |= 2; keys.delete('middle'); }
 	if(keys.has('right')){ pointerCode |= 4; keys.delete('right'); }
 	if(keys.has('4th')){ pointerCode |= 8; keys.delete('4th'); }
 	if(keys.has('5th')){ pointerCode |= 16; keys.delete('5th'); }
 
-	var modsCode = 0;
+	let modsCode = 0;
 	if(keys.has('ctrl')){ modsCode |= 1; keys.delete('ctrl'); }
 	if(keys.has('alt')){ modsCode |= 2; keys.delete('alt'); }
 	if(keys.has('shift')){ modsCode |= 4; keys.delete('shift'); }
@@ -241,7 +239,7 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 	// console.error(231, rootHandler, that, eventName, callback, options);
 
 	if(options.once === void 0){
-		(rootHandler || that)['sf$eventDestroy_'+eventName] = function(){
+		(rootHandler || that)[`sf$eventDestroy_${eventName}`] = function(){
 			(rootHandler || that).removeEventListener(eventName, callback, options);
 		}
 	}
@@ -251,11 +249,11 @@ function eventHandler(that, data, _modelScope, rootHandler, template){
 		that = null;
 }
 
-var toDegree = 180/Math.PI;
+const toDegree = 180/Math.PI;
 var specialEvent = internal.model.specialEvent = {
-	taphold:function(that, keys, script, _modelScope){
-		var set = new Set();
-		var evStart = null;
+	taphold(that, keys, script, _modelScope){
+		const set = new Set();
+		let evStart = null;
 
 		function callback(){
 			that.removeEventListener('pointerup', callbackEnd, {once:true});
@@ -320,12 +318,12 @@ var specialEvent = internal.model.specialEvent = {
 			that.removeEventListener('pointerdown', callbackStart);
 		}
 	},
-	gesture:function(that, keys, script, _modelScope){
+	gesture(that, keys, script, _modelScope){
 		touchGesture(that, function callback(data){
 			script.call(that, data);
 		});
 	},
-	dragmove:function(that, keys, script, _modelScope){
+	dragmove(that, keys, script, _modelScope){
 		that.style.touchAction = 'none';
 		function callbackMove(ev){
 			ev.stopPropagation();
@@ -336,8 +334,8 @@ var specialEvent = internal.model.specialEvent = {
 
 		function prevent(ev){ev.preventDefault()}
 
-		var view = document;
-		var callbackStart = function(ev){
+		let view = document;
+		const callbackStart = function(ev){
 			ev.preventDefault();
 			ev.stopPropagation();
 
@@ -372,7 +370,7 @@ var specialEvent = internal.model.specialEvent = {
 			document.removeEventListener('pointerup', callbackEnd, {once:true});
 		}
 	},
-	filedrop:function(that, keys, script, _modelScope){
+	filedrop(that, keys, script, _modelScope){
 		that.addEventListener('dragover', function dragover(ev){
 			ev.preventDefault();
 		});
@@ -381,8 +379,8 @@ var specialEvent = internal.model.specialEvent = {
 			ev.preventDefault();
 
 			if(ev.dataTransfer.items) {
-				var found = [];
-				for (var i = 0; i < ev.dataTransfer.items.length; i++) {
+				const found = [];
+				for (let i = 0; i < ev.dataTransfer.items.length; i++) {
 					if (ev.dataTransfer.items[i].kind === 'file')
 						found.push(ev.dataTransfer.items[i].getAsFile());
 				}
@@ -400,17 +398,17 @@ var specialEvent = internal.model.specialEvent = {
 };
 
 function touchGesture(that, callback){
-	var startScale = 0;
-	var startAngle = 0;
-	var lastScale = 0;
-	var lastAngle = 0;
-	var actionBackup = '';
+	let startScale = 0;
+	let startAngle = 0;
+	let lastScale = 0;
+	let lastAngle = 0;
+	let actionBackup = '';
 
-	var force = false;
-	var pointers = [];
+	let force = false;
+	const pointers = [];
 
 	function findAnd(action, ev){
-		for (var i = pointers.length - 1; i >= 0; i--) {
+		for (let i = pointers.length - 1; i >= 0; i--) {
 			if(pointers[i].pointerId === ev.pointerId){
 				if(action === 2) // delete
 					pointers.splice(i, 1);
@@ -424,8 +422,8 @@ function touchGesture(that, callback){
 			pointers.push(ev);
 	}
 
-	var view = document;
-	var callbackStart = function(ev){
+	let view = document;
+	const callbackStart = function(ev){
 		ev.preventDefault();
 		findAnd(0, ev);
 
@@ -449,8 +447,8 @@ function touchGesture(that, callback){
 		if(pointers.length === 2){
 			ev.stopPropagation();
 
-			var dx = pointers[1].clientX - pointers[0].clientX;
-			var dy = pointers[1].clientY - pointers[0].clientY;
+			const dx = pointers[1].clientX - pointers[0].clientX;
+			const dy = pointers[1].clientY - pointers[0].clientY;
 
 			lastScale = startScale = Math.sqrt(dx**2 + dy**2) * 0.01;
 			lastAngle = startAngle = Math.atan2(dy, dx) * toDegree;
@@ -472,13 +470,13 @@ function touchGesture(that, callback){
 		ev.stopImmediatePropagation();
 		findAnd(1, ev);
 
-		var p1 = pointers[0];
-		var p2 = pointers[1];
-		var dx = p2.clientX - p1.clientX;
-		var dy = p2.clientY - p1.clientY;
+		const p1 = pointers[0];
+		const p2 = pointers[1];
+		const dx = p2.clientX - p1.clientX;
+		const dy = p2.clientY - p1.clientY;
 
-		var currentScale = Math.sqrt(dx**2 + dy**2) * 0.01;
-		var currentAngle = Math.atan2(dy, dx) * toDegree;
+		const currentScale = Math.sqrt(dx**2 + dy**2) * 0.01;
+		const currentAngle = Math.atan2(dy, dx) * toDegree;
 
 		ev.scale = currentScale - lastScale;
 		ev.angle = currentAngle - lastAngle;

--- a/src/sf-model/event-handler.js
+++ b/src/sf-model/event-handler.js
@@ -348,7 +348,7 @@ var specialEvent = internal.model.specialEvent = {
 			view.addEventListener('pointercancel', callbackEnd, {once:true});
 		}
 
-		var callbackEnd = function(ev){
+		const callbackEnd = function(ev){
 			ev.preventDefault();
 			ev.stopPropagation();
 
@@ -359,7 +359,7 @@ var specialEvent = internal.model.specialEvent = {
 			view.removeEventListener('touchmove', prevent, {passive: false});
 			view.removeEventListener('pointercancel', callbackEnd, {once:true});
 			that.addEventListener('pointerdown', callbackStart, {once:true});
-		}
+		};
 
 		that.addEventListener('pointerdown', callbackStart);
 
@@ -464,7 +464,7 @@ function touchGesture(that, callback){
 		else view.removeEventListener('pointermove', callbackMove);
 	}
 
-	var callbackMove = function(ev){
+	const callbackMove = function(ev){
 		ev.preventDefault();
 		ev.stopPropagation();
 		ev.stopImmediatePropagation();
@@ -487,9 +487,9 @@ function touchGesture(that, callback){
 
 		lastScale = currentScale;
 		lastAngle = currentAngle;
-	}
+	};
 
-	var callbackEnd = function(ev){
+	const callbackEnd = function(ev){
 		ev.preventDefault();
 		findAnd(2, ev);
 
@@ -519,7 +519,7 @@ function touchGesture(that, callback){
 				callback(ev);
 			}
 		}
-	}
+	};
 
 	that.addEventListener('pointerdown', callbackStart);
 
@@ -528,7 +528,7 @@ function touchGesture(that, callback){
 		$(sf.window).off('keydown', keyStart);
 	}
 
-	var keyEnd = function(ev){
+	const keyEnd = function(ev){
 		if(!force || ev.ctrlKey)
 			return;
 
@@ -537,9 +537,9 @@ function touchGesture(that, callback){
 
 		view.removeEventListener('pointermove', callbackMove);
 		view.removeEventListener('keyup', keyEnd);
-	}
+	};
 
-	var keyStart = function(ev){
+	const keyStart = function(ev){
 		if(!ev.ctrlKey)
 			return;
 
@@ -547,7 +547,7 @@ function touchGesture(that, callback){
 
 		force = true;
 		view.addEventListener('keyup', keyEnd);
-	}
+	};
 
 	$(sf.window).on('keydown', keyStart);
 }

--- a/src/sf-model/input-bind.js
+++ b/src/sf-model/input-bind.js
@@ -1,11 +1,11 @@
-var inputBoundRunning = false;
-var callInputListener = function(ref, value){
-	var v2m = ref.sfModel['v2m$'+ref.sfBounded];
-	var on = ref.sfModel['on$'+ref.sfBounded];
+let inputBoundRunning = false;
+const callInputListener = function(ref, value){
+	const v2m = ref.sfModel[`v2m$${ref.sfBounded}`];
+	const on = ref.sfModel[`on$${ref.sfBounded}`];
 
 	if(v2m !== void 0 || on !== void 0){
-		var newValue;
-		var old = ref.sfModel[ref.sfBounded];
+		let newValue;
+		let old = ref.sfModel[ref.sfBounded];
 
 		if(old !== null && old !== void 0 && old.constructor === Array)
 			old = old.slice(0);
@@ -28,13 +28,13 @@ var callInputListener = function(ref, value){
 	}
 }
 
-var inputTextBound = function(e){
+const inputTextBound = function(e){
 	if(e.fromSFFramework === true) return;
 
-	var ref = inputBoundRunning = e.target;
+	const ref = inputBoundRunning = e.target;
 	ref.viewInputted = true;
-	var value = ref.typeData === Number ? Number(ref.value) : ref.value;
-	var newValue = callInputListener(ref, value);
+	const value = ref.typeData === Number ? Number(ref.value) : ref.value;
+	const newValue = callInputListener(ref, value);
 
 	if(ref.sfFeedback){
 		ref.sfFeedback = false;
@@ -44,17 +44,17 @@ var inputTextBound = function(e){
 	ref.sfModel[ref.sfBounded] = newValue !== void 0 ? newValue : value;
 }
 
-var inputFilesBound = function(e){
+const inputFilesBound = function(e){
 	if(e.fromSFFramework === true) return;
 
-	var ref = e.target;
-	var newValue = callInputListener(ref, ref.files);
+	const ref = e.target;
+	const newValue = callInputListener(ref, ref.files);
 	if(newValue !== void 0){
 		if(!newValue || newValue.length === 0)
 			ref.value = '';
 		else{
-			var temp = new DataTransfer();
-			for (var i = 0; i < newValue.length; i++)
+			const temp = new DataTransfer();
+			for (let i = 0; i < newValue.length; i++)
 				temp.items.add(newValue[i]);
 
 			ref.sfModel[ref.sfBounded] = temp.files;
@@ -67,24 +67,24 @@ var inputFilesBound = function(e){
 	else ref.sfModel[ref.sfBounded] = ref.files;
 }
 
-var inputCheckBoxBound = function(e){
+const inputCheckBoxBound = function(e){
 	if(e.fromSFFramework === true) return;
 
-	var ref = inputBoundRunning = e.target;
+	const ref = inputBoundRunning = e.target;
 	ref.viewInputted = true;
 
-	var model = ref.sfModel;
-	var constructor = model[ref.sfBounded].constructor;
+	const model = ref.sfModel;
+	const { constructor } = model[ref.sfBounded];
 
-	var value;
+	let value;
 	if(constructor === Boolean || ref.typeData === Boolean)
 		value = ref.checked;
 	else if(ref.typeData === Number)
 		value = Number(ref.value);
 	else
-		value = ref.value;
+		({ value } = ref);
 
-	var newValue = callInputListener(ref, value);
+	const newValue = callInputListener(ref, value);
 	if(newValue !== void 0){
 		value = newValue;
 
@@ -95,7 +95,7 @@ var inputCheckBoxBound = function(e){
 	}
 
 	if(constructor === Array){
-		var i = model[ref.sfBounded].indexOf(value);
+		const i = model[ref.sfBounded].indexOf(value);
 
 		if(i === -1 && ref.checked === true)
 			model[ref.sfBounded].push(value);
@@ -105,22 +105,22 @@ var inputCheckBoxBound = function(e){
 	else model[ref.sfBounded] = value;
 }
 
-var inputSelectBound = function(e){
+const inputSelectBound = function(e){
 	if(e.fromSFFramework === true) return;
 
-	var ref = inputBoundRunning = e.target;
+	const ref = inputBoundRunning = e.target;
 	ref.viewInputted = true;
-	var typeData = ref.typeData;
+	const { typeData } = ref;
 
-	var value = [];
+	let value = [];
 	if(ref.multiple === true){
-		var temp = ref.selectedOptions;
-		for (var i = 0; i < temp.length; i++)
+		const temp = ref.selectedOptions;
+		for (let i = 0; i < temp.length; i++)
 			value.push(typeData === Number ? Number(temp[i].value) : temp[i].value);
 	}
 	else value = typeData === Number ? Number(ref.selectedOptions[0].value) : ref.selectedOptions[0].value;
 
-	var newValue = callInputListener(ref, value);
+	const newValue = callInputListener(ref, value);
 	if(newValue !== void 0){
 		if(ref.sfFeedback){
 			ref.sfFeedback = false;
@@ -133,9 +133,9 @@ var inputSelectBound = function(e){
 }
 
 var assignElementData = {
-	select:function(val, element){
-		var list = element.options;
-		var typeData = element.typeData;
+	select(val, element){
+		const list = element.options;
+		const { typeData } = element;
 
 		if(val.constructor !== Array){
 			for (var i = 0, n = list.length; i < n; i++) {
@@ -147,7 +147,7 @@ var assignElementData = {
 		else for (var i = 0, n = list.length; i < n; i++)
 			list[i].selected = val.includes(typeData === Number ? Number(list[i].value) : list[i].value);
 	},
-	checkbox:function(val, element){
+	checkbox(val, element){
 		if(val.constructor === Array)
 			element.checked = val.includes(element.typeData === Number ? Number(element.value) : element.value);
 		else if(val.constructor === Boolean)
@@ -158,12 +158,12 @@ var assignElementData = {
 			else element.checked = element.value == val;
 		}
 	},
-	file:function(val, element){
+	file(val, element){
 		if(!val || val.length === 0)
 			element.value = '';
 		else{
-			var temp = new DataTransfer();
-			for (var i = 0; i < val.length; i++)
+			const temp = new DataTransfer();
+			for (let i = 0; i < val.length; i++)
 				temp.items.add(val[i]);
 
 			element.files = temp.files;
@@ -171,11 +171,11 @@ var assignElementData = {
 	}
 }
 
-var inputBoundRun = function(val, elements){
+const inputBoundRun = function(val, elements){
 	if(val === null || val === void 0)
 		return;
 
-	for (var i = 0; i < elements.length; i++) {
+	for (let i = 0; i < elements.length; i++) {
 		if(inputBoundRunning === elements[i])
 			continue; // Avoid multiple assigment
 
@@ -192,7 +192,7 @@ var inputBoundRun = function(val, elements){
 			continue;
 		}
 
-		var ev = new Event('change');
+		const ev = new Event('change');
 		ev.fromSFFramework = true;
 		elements[i].dispatchEvent(ev);
 	}
@@ -201,7 +201,7 @@ var inputBoundRun = function(val, elements){
 // For dynamic reference checking
 inputBoundRun.inputBoundRun = true;
 
-var triggerInputEvent = function(e){
+const triggerInputEvent = function(e){
 	if(e.fromSFFramework === true) return;
 	if(e.target.viewInputted === true){
 		e.target.viewInputted = false;
@@ -210,19 +210,19 @@ var triggerInputEvent = function(e){
 	e.target.dispatchEvent(new Event('input'));
 }
 
-var elementBoundChanges = function(model, property, element, oneWay, modelLocal, propertyNameLocal){
+const elementBoundChanges = function(model, property, element, oneWay, modelLocal, propertyNameLocal){
 	// Enable multiple element binding
 	if(model.sf$bindedKey === void 0)
 		initBindingInformation(model);
 
-	var val = model[property];
+	const val = model[property];
 
 	var type = 0;
-	var typeData = null;
+	let typeData = null;
 	if(val !== null && val !== void 0)
 		typeData = val.constructor;
 
-	var assignedType = (element.getAttribute('typedata') || '').toLowerCase();
+	const assignedType = (element.getAttribute('typedata') || '').toLowerCase();
 	if(assignedType === 'number')
 		typeData = Number;
 
@@ -274,10 +274,10 @@ var elementBoundChanges = function(model, property, element, oneWay, modelLocal,
 	modelToViewBinding(modelLocal, propertyNameLocal || property, inputBoundRun, element, type);
 }
 
-var bindInput = internal.model.bindInput = function(temp, modelLocal, mask, modelScope){
-	var element, oneWay, propertyName;
+const bindInput = internal.model.bindInput = function(temp, modelLocal, mask, modelScope){
+	let element, oneWay, propertyName;
 
-	for (var i = 0; i < temp.length; i++) {
+	for (let i = 0; i < temp.length; i++) {
 		if(temp[i].getAttribute === void 0){
 			element = temp[i].el;
 			oneWay = temp[i].id === 1;
@@ -302,8 +302,8 @@ var bindInput = internal.model.bindInput = function(temp, modelLocal, mask, mode
 			continue;
 		}
 
-		var model = modelLocal;
-		var currentModel = modelLocal;
+		let model = modelLocal;
+		let currentModel = modelLocal;
 		if(mask !== void 0){
 			if(propertyName.indexOf(mask+'.') === 0)
 				propertyName = propertyName.replace(/\w+\./, '');
@@ -312,9 +312,9 @@ var bindInput = internal.model.bindInput = function(temp, modelLocal, mask, mode
 		}
 
 		// Get reference
-		var propertyNameLocal = null;
+		let propertyNameLocal = null;
 		if(model[propertyName] === void 0){
-			var deepScope = parsePropertyPath(propertyName);
+			let deepScope = parsePropertyPath(propertyName);
 			propertyNameLocal = deepScope.slice();
 
 			if(deepScope.length !== 1){
@@ -324,7 +324,7 @@ var bindInput = internal.model.bindInput = function(temp, modelLocal, mask, mode
 			else deepScope = void 0;
 
 			if(deepScope === void 0){
-				console.error('Can\'t get property "'+propertyName+'" on model', model);
+				console.error(`Can't get property "${propertyName}" on model`, model);
 				return;
 			}
 

--- a/src/sf-model/repeated-list.js
+++ b/src/sf-model/repeated-list.js
@@ -5,10 +5,10 @@
 // - we also need to support bind into array key if specified
 
 // var warnUnsupport = true;
-var repeatedListBinding = internal.model.repeatedListBinding = function(elements, modelRef, namespace, modelKeysRegex){
-	var element, script;
+const repeatedListBinding = internal.model.repeatedListBinding = function(elements, modelRef, namespace, modelKeysRegex){
+	let element, script;
 
-	for (var i = 0; i < elements.length; i++) {
+	for (let i = 0; i < elements.length; i++) {
 		if(elements[i].getAttribute === void 0){
 			element = elements[i].el;
 			script = elements[i].rule;
@@ -26,7 +26,7 @@ var repeatedListBinding = internal.model.repeatedListBinding = function(elements
 
 		element.sf$componentIgnore = true;
 
-		var pattern = script.match(sfRegex.repeatedList);
+		let pattern = script.match(sfRegex.repeatedList);
 		if(pattern === null){
 			console.error("'", script, "' should match the pattern like `key,val in list`");
 			continue;
@@ -36,9 +36,9 @@ var repeatedListBinding = internal.model.repeatedListBinding = function(elements
 		if(pattern[0].includes(','))
 			pattern[0] = pattern[0].split(' ').join('').split(',');
 
-		var target = modelRef[pattern[1]];
+		let target = modelRef[pattern[1]];
 		if(target === void 0){
-			var isDeep = parsePropertyPath(pattern[1]);
+			const isDeep = parsePropertyPath(pattern[1]);
 			if(isDeep.length !== 1){
 				pattern[1] = isDeep;
 				target = deepProperty(modelRef, isDeep);
@@ -59,7 +59,7 @@ var repeatedListBinding = internal.model.repeatedListBinding = function(elements
 			modelRef.sf$bindedKey[pattern[1]] = true;
 		}
 
-		var constructor = target.constructor;
+		const { constructor } = target;
 
 		if(constructor === Array || constructor === RepeatedList){
 			RepeatedList.construct(modelRef, element, pattern, element.parentNode, namespace, modelKeysRegex);
@@ -76,7 +76,7 @@ var repeatedListBinding = internal.model.repeatedListBinding = function(elements
 }
 
 function prepareRepeated(modelRef, element, pattern, parentNode, namespace, modelKeysRegex){
-	var callback, prop = pattern[1], targetDeep;
+	let callback, prop = pattern[1], targetDeep;
 
 	if(prop.constructor !== Array)
 		targetDeep = modelRef;
@@ -85,23 +85,23 @@ function prepareRepeated(modelRef, element, pattern, parentNode, namespace, mode
 		prop = prop[prop.length - 1];
 	}
 
-	callback = targetDeep['on$'+prop] || {};
+	callback = targetDeep[`on$${prop}`] || {};
 
-	var compTemplate = (namespace || sf.component).registered[element.tagName.toLowerCase()];
+	const compTemplate = (namespace || sf.component).registered[element.tagName.toLowerCase()];
 	if(compTemplate !== void 0 && compTemplate[3] === false && element.childNodes.length !== 0)
 		compTemplate[3] = element;
 
-	var isComponent = compTemplate !== void 0 ? compTemplate[1] : false;
-	var EM = new ElementManipulator();
+	const isComponent = compTemplate !== void 0 ? compTemplate[1] : false;
+	const EM = new ElementManipulator();
 
 	if(this.$EM === void 0){
 		hiddenProperty(this, '$EM', EM, true);
-		Object.defineProperty(targetDeep, 'on$'+prop, {
+		Object.defineProperty(targetDeep, `on$${prop}`, {
 			configurable: true,
-			get:function(){
+			get(){
 				return callback;
 			},
-			set:function(val){
+			set(val){
 				Object.assign(callback, val);
 			}
 		});
@@ -109,12 +109,12 @@ function prepareRepeated(modelRef, element, pattern, parentNode, namespace, mode
 	else if(this.$EM.constructor === ElementManipulatorProxy)
 		this.$EM.list.push(EM);
 	else{
-		var newList = [this.$EM, EM];
+		const newList = [this.$EM, EM];
 		this.$EM = new ElementManipulatorProxy();
 		this.$EM.list = newList;
 	}
 
-	var mask = pattern[0], uniqPattern;
+	let mask = pattern[0], uniqPattern;
 	if(mask.constructor === Array){
 		uniqPattern = mask[0];
 		mask = mask.pop();
@@ -122,12 +122,12 @@ function prepareRepeated(modelRef, element, pattern, parentNode, namespace, mode
 
 	EM.asScope = void 0;
 
-	var template;
+	let template;
 	if(!isComponent){
 		// Get reference for debugging
 		processingElement = element;
 
-		var container;
+		let container;
 		if(element.namespaceURI === 'http://www.w3.org/2000/svg' && element.tagName !== 'SVG')
 			container = 'svg';
 
@@ -151,14 +151,14 @@ function prepareRepeated(modelRef, element, pattern, parentNode, namespace, mode
 	if(uniqPattern !== void 0)
 		EM.template.uniqPattern = uniqPattern;
 
-	var nextSibling = element.nextSibling;
+	const { nextSibling } = element;
 	element.remove();
 
 	// check if alone
 	if(parentNode.childNodes.length <= 1 || parentNode.textContent.trim().length === 0)
 		return true;
 
-	var that = this;
+	const that = this;
 	return function(){
 		EM.bound_end = document.createComment('');
 		parentNode.insertBefore(EM.bound_end, nextSibling);
@@ -174,20 +174,20 @@ function prepareRepeated(modelRef, element, pattern, parentNode, namespace, mode
 
 class RepeatedProperty{ // extends Object
 	static construct(modelRef, element, pattern, parentNode, namespace, modelKeysRegex){
-		var prop = pattern[1];
-		var that = prop.constructor === String ? modelRef[prop] : deepProperty(modelRef, prop);
+		let prop = pattern[1];
+		const that = prop.constructor === String ? modelRef[prop] : deepProperty(modelRef, prop);
 
 		// Initialize property once
 		if(that.constructor !== RepeatedProperty){
 			// Hide property that have $
-			for(var k in that){
+			for(let k in that){
 				if(k.includes('$'))
 					hiddenProperty(that, k, that[k], true);
 			}
 
 			hiddenProperty(that, '_list', Object.keys(that));
 
-			var target;
+			let target;
 			if(prop.constructor !== Array)
 				target = modelRef;
 			else{
@@ -199,12 +199,12 @@ class RepeatedProperty{ // extends Object
 			Object.defineProperty(target, prop, {
 				enumerable: true,
 				configurable: true,
-				get:function(){
+				get(){
 					return that;
 				},
-				set:function(val){
-					var olds = that._list;
-					var news = Object.keys(val);
+				set(val){
+					const olds = that._list;
+					const news = Object.keys(val);
 
 					// Assign if keys order was similar
 					for (var a = 0; a < olds.length; a++) {
@@ -230,11 +230,11 @@ class RepeatedProperty{ // extends Object
 			});
 		}
 
-		var alone = prepareRepeated.apply(that, arguments);
-		var EM = that.$EM.constructor === ElementManipulatorProxy ? that.$EM.list[that.$EM.list.length-1] : that.$EM;
+		const alone = prepareRepeated.apply(that, arguments);
+		const EM = that.$EM.constructor === ElementManipulatorProxy ? that.$EM.list[that.$EM.list.length-1] : that.$EM;
 
 		// Proxy known property
-		for(var key in that)
+		for(let key in that)
 			ProxyProperty(that, key, true);
 
 		if(alone === true){
@@ -246,14 +246,14 @@ class RepeatedProperty{ // extends Object
 	}
 
 	$el(selector){
-		var $EM = this.$EM;
+		const { $EM } = this;
 		if($EM.constructor === ElementManipulatorProxy)
 			return $EM.$el(selector)
 		return $(queryElements(($EM.parentChilds || $EM.elements), selector));
 	}
 
 	getElement(prop){
-		var $EM = this.$EM;
+		let { $EM } = this;
 		if($EM.constructor === ElementManipulatorProxy)
 			$EM = $EM.list[0];
 
@@ -275,17 +275,17 @@ class RepeatedProperty{ // extends Object
 		if(this.$EM.constructor === ElementManipulatorProxy)
 			return this.$EM.refresh_RP(this);
 
-		var elemList = (this.$EM.parentChilds || this.$EM.elements);
+		const elemList = (this.$EM.parentChilds || this.$EM.elements);
 		if(elemList === void 0)
 			return;
 
 		// If single RepeatedElement instance
-		var list = this._list;
-		for (var i = 0; i < list.length; i++) {
-			var elem = elemList[i];
+		const list = this._list;
+		for (let i = 0; i < list.length; i++) {
+			const elem = elemList[i];
 
 			if(this[list[i]] !== elem.model){
-				var newElem = this.$EM.createElement(list[i]);
+				const newElem = this.$EM.createElement(list[i]);
 				this.$EM.parentNode.replaceChild(newElem, elem);
 
 				if(this.$EM.elements !== void 0)
@@ -320,7 +320,7 @@ sf.delete = function(obj, prop){
 		return;
 	}
 
-	var i = obj._list.indexOf(prop);
+	const i = obj._list.indexOf(prop);
 	if(i === -1)
 		return;
 
@@ -332,13 +332,13 @@ sf.delete = function(obj, prop){
 
 function ProxyProperty(obj, prop, force){
 	if(force || Object.getOwnPropertyDescriptor(obj, prop).set === void 0){
-		var temp = obj[prop];
+		let temp = obj[prop];
 
 		Object.defineProperty(obj, prop, {
 			configurable:true,
 			enumerable:true,
-			get:function(){return temp},
-			set:function(val){
+			get(){return temp},
+			set(val){
 				temp = val;
 				obj.refresh(prop);
 			}
@@ -349,17 +349,17 @@ function ProxyProperty(obj, prop, force){
 // This is called only once when RepeatedProperty/RepeatedList is initializing
 // So we don't need to use cache
 function injectArrayElements(EM, tempDOM, beforeChild, that, modelRef, parentNode, namespace){
-	var temp,
-		isComponent = EM.isComponent,
-		template = EM.template;
+	let temp,
+		{ isComponent,
+		template } = EM;
 
 	if(that.constructor === RepeatedProperty){
 		temp = that;
 		that = Object.values(that);
 	}
 
-	var len = that.length;
-	var elem;
+	const len = that.length;
+	let elem;
 	for (var i = 0; i < len; i++) {
 		if(isComponent)
 			elem = new template(that[i], namespace, EM.asScope);
@@ -389,19 +389,19 @@ function injectArrayElements(EM, tempDOM, beforeChild, that, modelRef, parentNod
 
 	if(temp !== void 0){
 		var i = 0;
-		for(var keys in temp)
+		for(let keys in temp)
 			temp[keys] = that[i++];
 	}
 }
 
 class RepeatedList extends Array{
 	static construct(modelRef, element, pattern, parentNode, namespace, modelKeysRegex){
-		var prop = pattern[1];
-		var that = prop.constructor === String ? modelRef[prop] : deepProperty(modelRef, prop);
+		let prop = pattern[1];
+		const that = prop.constructor === String ? modelRef[prop] : deepProperty(modelRef, prop);
 
 		// Initialize property once
 		if(that.constructor !== RepeatedList){
-			var target;
+			let target;
 			if(prop.constructor !== Array)
 				target = modelRef;
 			else{
@@ -413,10 +413,10 @@ class RepeatedList extends Array{
 			Object.defineProperty(target, prop, {
 				enumerable: true,
 				configurable: true,
-				get:function(){
+				get(){
 					return that;
 				},
-				set:function(val){
+				set(val){
 					if(val.length === 0)
 						that.splice(0);
 					else that.remake(val, true);
@@ -424,9 +424,9 @@ class RepeatedList extends Array{
 			});
 		}
 
-		var alone = prepareRepeated.apply(that, arguments);
-		var EM = that.$EM.constructor === ElementManipulatorProxy ? that.$EM.list[that.$EM.list.length-1] : that.$EM;
-		var template = EM.template;
+		const alone = prepareRepeated.apply(that, arguments);
+		const EM = that.$EM.constructor === ElementManipulatorProxy ? that.$EM.list[that.$EM.list.length-1] : that.$EM;
+		const { template } = EM;
 
 		if(parentNode.classList.contains('sf-virtual-list')){
 			hiddenProperty(that, '$virtual', new VirtualScroll(EM));
@@ -450,12 +450,12 @@ class RepeatedList extends Array{
 
 		// Wait for scroll plugin initialization
 		setTimeout(function(){
-			var scroller = internal.findScrollerElement(parentNode);
+			const scroller = internal.findScrollerElement(parentNode);
 			if(scroller === null) return;
 
 			internal.addScrollerStyle();
 
-			var computed = getComputedStyle(scroller);
+			const computed = getComputedStyle(scroller);
 			if(computed.backfaceVisibility === 'hidden' || computed.overflow.includes('hidden'))
 				return;
 
@@ -464,7 +464,7 @@ class RepeatedList extends Array{
 	}
 
 	$el(selector){
-		var $EM = this.$EM;
+		const { $EM } = this;
 		if($EM.constructor === ElementManipulatorProxy)
 			return $EM.$el(selector)
 		return $(queryElements(($EM.parentChilds || $EM.elements), selector));
@@ -476,7 +476,7 @@ class RepeatedList extends Array{
 	}
 
 	push(){
-		var lastLength = this.length;
+		const lastLength = this.length;
 		Array.prototype.push.apply(this, arguments);
 
 		if(arguments.length === 1)
@@ -492,14 +492,14 @@ class RepeatedList extends Array{
 			return Array.prototype.splice.apply(this, arguments);
 		}
 
-		var lastLength = this.length;
-		var ret = Array.prototype.splice.apply(this, arguments);
+		const lastLength = this.length;
+		const ret = Array.prototype.splice.apply(this, arguments);
 
 		// Removing data
-		var real = arguments[0];
+		let real = arguments[0];
 		if(real < 0) real = lastLength + real;
 
-		var limit = arguments[1];
+		let limit = arguments[1];
 		if(!limit && limit !== 0) limit = this.length;
 
 		for (var i = limit - 1; i >= 0; i--)
@@ -520,7 +520,7 @@ class RepeatedList extends Array{
 	}
 
 	shift(){
-		var ret = Array.prototype.shift.apply(this, arguments);
+		const ret = Array.prototype.shift.apply(this, arguments);
 
 		this.$EM.remove(0);
 		return ret;
@@ -533,7 +533,7 @@ class RepeatedList extends Array{
 			this.$EM.prepend(0);
 
 		else{
-			for (var i = arguments.length - 1; i >= 0; i--)
+			for (let i = arguments.length - 1; i >= 0; i--)
 				this.$EM.prepend(i);
 		}
 
@@ -558,11 +558,11 @@ class RepeatedList extends Array{
 
 		if(removes !== void 0){
 			if(removes.constructor === Object){
-				var temp = {};
+				const temp = {};
 
-				for(var key in removes){
+				for(let key in removes){
 					if(key.slice(-1) === ']'){
-						var k = key.split('[');
+						const k = key.split('[');
 						switch(k[1]){
 							case "!]":
 							if(temp.b === void 0) temp.b = [];
@@ -599,7 +599,7 @@ class RepeatedList extends Array{
 				removes = temp;
 			}
 
-			var processed;
+			let processed;
 			if(putLast === true)
 				processed = new WeakSet();
 
@@ -608,7 +608,7 @@ class RepeatedList extends Array{
 					break;
 
 				if(removes.constructor === Object){
-					var temp1 = this[i];
+					const temp1 = this[i];
 					if(removes.a !== void 0){ // ===
 						for(var z=0, n=removes.a.length; z < n; z++){
 							var temp2 = removes.a[z];
@@ -660,7 +660,7 @@ class RepeatedList extends Array{
 					continue;
 				}
 
-				var current = withArray.shift();
+				const current = withArray.shift();
 				if(this[i] !== current)
 					Object.assign(this[i], current);
 
@@ -694,7 +694,7 @@ class RepeatedList extends Array{
 		if(withArray.length === this.length || fromIndex !== 0)
 			return this;
 
-		var lastLength = this.length;
+		const lastLength = this.length;
 		if(withArray.length > this.length){
 			Array.prototype.push.apply(this, withArray.slice(this.length));
 			this.$EM.hardRefresh(lastLength);
@@ -709,11 +709,11 @@ class RepeatedList extends Array{
 	}
 
 	remake(newList, atMiddle){
-		var lastLength = this.length;
+		const lastLength = this.length;
 
 		// Check if item has same reference
 		if(newList.length >= lastLength && lastLength !== 0){
-			var matchLeft = lastLength;
+			let matchLeft = lastLength;
 
 			for (var i = 0; i < lastLength; i++) {
 				if(newList[i] === this[i]){
@@ -780,7 +780,7 @@ class RepeatedList extends Array{
 	swap(i, o){
 		if(i === o) return;
 		this.$EM.swap(i, o);
-		var temp = this[i];
+		const temp = this[i];
 		this[i] = this[o];
 		this[o] = temp;
 	}
@@ -793,14 +793,14 @@ class RepeatedList extends Array{
 
 		this.$EM.move(from, to, count);
 
-		var temp = Array.prototype.splice.call(this, from, count);
+		const temp = Array.prototype.splice.call(this, from, count);
 		temp.unshift(to, 0);
 		Array.prototype.splice.apply(this, temp);
 	}
 
 	// Return single element from first $EM
 	getElement(index){
-		var $EM = this.$EM;
+		let { $EM } = this;
 		if($EM.constructor === ElementManipulatorProxy)
 			$EM = $EM.list[0];
 
@@ -845,14 +845,14 @@ class RepeatedList extends Array{
 	refresh(index, length){
 		if(index === void 0 || index.constructor === String){
 			index = 0;
-			length = this.length;
+			({ length } = this);
 		}
 		else if(length === void 0) length = index + 1;
 		else if(length < 0) length = this.length + length;
 		else length += index;
 
 		// Trim length
-		var overflow = this.length - length;
+		const overflow = this.length - length;
 		if(overflow < 0) length = length + overflow;
 
 		if(this.$EM.constructor === ElementManipulatorProxy)
@@ -860,7 +860,7 @@ class RepeatedList extends Array{
 		else
 			var elems = this.$EM.parentChilds || this.$EM.elements;
 
-		for (var i = index; i < length; i++) {
+		for (let i = index; i < length; i++) {
 			// Create element if not exist
 			if(elems[i] === void 0){
 				this.$EM.hardRefresh(i);
@@ -880,11 +880,11 @@ class RepeatedList extends Array{
 
 class ElementManipulator{
 	createElement(index){
-		var item = this.list[index];
+		const item = this.list[index];
 		if(item === void 0) return;
 
-		var template = this.template;
-		var temp = this.elementRef && this.elementRef.get(item);
+		const { template } = this;
+		let temp = this.elementRef && this.elementRef.get(item);
 
 		if(temp !== void 0){
 			if(temp.model.$el === void 0){
@@ -928,8 +928,8 @@ class ElementManipulator{
 
 	// Recreate the item element after the index
 	hardRefresh(index){
-		var list = this.list;
-		var exist = this.parentChilds || this.elements;
+		const { list } = this;
+		const exist = this.parentChilds || this.elements;
 
 		if(this.template.modelRefRoot_path && this.template.modelRefRoot_path.length !== 0)
 			this.clearBinding(exist, index);
@@ -955,8 +955,8 @@ class ElementManipulator{
 			exist.length = list.length;
 
 		for (var i = index; i < list.length; i++) {
-			var ref = list[i];
-			var temp = this.elementRef.get(ref);
+			const ref = list[i];
+			let temp = this.elementRef.get(ref);
 
 			if(temp === void 0){
 				if(this.isComponent)
@@ -1007,9 +1007,9 @@ class ElementManipulator{
 	}
 
 	update(index, other){
-		var exist = this.parentChilds || this.elements;
-		var list = this.list;
-		var template = this.template;
+		const exist = this.parentChilds || this.elements;
+		const { list } = this;
+		const { template } = this;
 
 		if(index === void 0){
 			index = 0;
@@ -1020,19 +1020,19 @@ class ElementManipulator{
 		else other += index;
 
 		// Trim length
-		var overflow = list.length - other;
+		const overflow = list.length - other;
 		if(overflow < 0) other = other + overflow;
 
 		if(this.template.modelRefRoot_path && this.template.modelRefRoot_path.length !== 0)
 			this.clearBinding(exist, index, other);
 
-		for (var i = index; i < other; i++) {
-			var oldChild = exist[i];
+		for (let i = index; i < other; i++) {
+			const oldChild = exist[i];
 			if(oldChild === void 0 || list[i] === void 0)
 				break;
 
-			var ref = list[i];
-			var temp = this.elementRef.get(ref);
+			const ref = list[i];
+			let temp = this.elementRef.get(ref);
 
 			if(temp === void 0){
 				if(this.isComponent)
@@ -1088,18 +1088,18 @@ class ElementManipulator{
 	}
 
 	move(from, to, count){
-		var exist = this.parentChilds || this.elements;
+		const exist = this.parentChilds || this.elements;
 
-		var overflow = this.list.length - from - count;
+		const overflow = this.list.length - from - count;
 		if(overflow < 0)
 			count += overflow;
 
-		var vDOM = new Array(count);
+		const vDOM = new Array(count);
 		for (var i = 0; i < count; i++)
 			(vDOM[i] = exist[from + i]).remove();
 
 		if(this.$VSM === void 0){
-			var nextSibling = exist[to] || null;
+			const nextSibling = exist[to] || null;
 
 			// Move to defined index
 			for (var i = 0; i < count; i++) {
@@ -1119,11 +1119,11 @@ class ElementManipulator{
 	}
 
 	swap(index, other){
-		var exist = this.parentChilds || this.elements;
+		const exist = this.parentChilds || this.elements;
 
-		var ii=index, oo=other;
+		const ii=index, oo=other;
 		if(index > other){
-			var index_a = exist[other];
+			const index_a = exist[other];
 			other = exist[index];
 			index = index_a;
 		} else {
@@ -1132,14 +1132,14 @@ class ElementManipulator{
 		}
 
 		if(this.elements !== void 0){
-			var temp = exist[ii];
+			const temp = exist[ii];
 			exist[ii] = exist[oo];
 			exist[oo] = exist[ii];
 		}
 
 		if(this.$VSM === void 0){
-			var other_sibling = other.nextSibling;
-			var other_parent = other.parentNode;
+			const other_sibling = other.nextSibling;
+			const other_parent = other.parentNode;
 			index.parentNode.insertBefore(other, index.nextSibling);
 			other_parent.insertBefore(index, other_sibling);
 		}
@@ -1152,17 +1152,17 @@ class ElementManipulator{
 	}
 
 	remove(index){
-		var exist = this.parentChilds || this.elements;
+		const exist = this.parentChilds || this.elements;
 
 		if(this.template.modelRefRoot_path && this.template.modelRefRoot_path.length !== 0)
 			this.clearBinding(exist, index, index+1);
 
 		if(exist[index]){
-			var currentEl = exist[index];
+			const currentEl = exist[index];
 
 			if(this.callback.remove){
-				var currentRemoved = false;
-				var startRemove = function(){
+				let currentRemoved = false;
+				const startRemove = function(){
 					if(currentRemoved) return;
 					currentRemoved = true;
 
@@ -1185,9 +1185,9 @@ class ElementManipulator{
 	}
 
 	removeRange(index, other){
-		var exist = this.parentChilds || this.elements;
+		const exist = this.parentChilds || this.elements;
 
-		for (var i = index; i < other; i++)
+		for (let i = index; i < other; i++)
 			exist[index].remove();
 
 		if(this.template.modelRefRoot_path && this.template.modelRefRoot_path.length !== 0)
@@ -1213,14 +1213,14 @@ class ElementManipulator{
 	}
 
 	insertAfter(index){
-		var exist = this.parentChilds || this.elements;
-		var temp = this.createElement(index);
+		const exist = this.parentChilds || this.elements;
+		const temp = this.createElement(index);
 
 		if(this.$VSM === void 0){
 			if(exist.length === 0)
 				this.parentNode.insertBefore(temp, this.parentNode.lastElementChild);
 			else{
-				var referenceNode = exist[index-1];
+				const referenceNode = exist[index-1];
 				referenceNode.parentNode.insertBefore(temp, referenceNode.nextSibling);
 			}
 		}
@@ -1235,11 +1235,11 @@ class ElementManipulator{
 	}
 
 	prepend(index){
-		var exist = this.parentChilds || this.elements;
-		var temp = this.createElement(index);
+		const exist = this.parentChilds || this.elements;
+		const temp = this.createElement(index);
 
 		if(this.$VSM === void 0){
-			var referenceNode = exist[0];
+			const referenceNode = exist[0];
 			if(referenceNode !== void 0){
 				referenceNode.parentNode.insertBefore(temp, referenceNode);
 
@@ -1256,8 +1256,8 @@ class ElementManipulator{
 	}
 
 	append(index){
-		var exist = this.parentChilds || this.elements;
-		var temp = this.createElement(index);
+		const exist = this.parentChilds || this.elements;
+		const temp = this.createElement(index);
 
 		if(this.elements !== void 0)
 			exist.push(temp);
@@ -1276,17 +1276,17 @@ class ElementManipulator{
 
 	reverse(){
 		if(this.parentChilds !== void 0){
-			var len = this.parentChilds.length;
+			const len = this.parentChilds.length;
 			if(len === 0)
 				return;
 
-			var beforeChild = this.parentChilds[0];
+			const beforeChild = this.parentChilds[0];
 			for (var i = 1; i < len; i++) {
 				this.parentNode.insertBefore(this.parentNode.lastElementChild, beforeChild);
 			}
 		}
 		else{
-			var elems = this.elements;
+			const elems = this.elements;
 			elems.reverse();
 
 			if(this.$VSM)
@@ -1305,8 +1305,8 @@ class ElementManipulator{
 		if(to === void 0)
 			to = this.list.length;
 
-		var modelRoot = this.modelRef;
-		var binded = this.template.modelRefRoot_path;
+		const modelRoot = this.modelRef;
+		const binded = this.template.modelRefRoot_path;
 
 		if(elemList.constructor !== Array){
 			// Loop for every element between range first (important)
@@ -1357,17 +1357,17 @@ class ElementManipulator{
 
 class ElementManipulatorProxy{
 	refresh_RP(instance){
-		var list = this.list;
-		var keys = instance._list;
-		for (var i = 0; i < list.length; i++) {
-			var EM = list[i];
-			var elemList = (EM.parentChilds || EM.elements);
+		const { list } = this;
+		const keys = instance._list;
+		for (let i = 0; i < list.length; i++) {
+			const EM = list[i];
+			const elemList = (EM.parentChilds || EM.elements);
 
 			if(elemList === void 0)
 				continue;
 
-			for (var a = 0; a < keys.length; a++) {
-				var elem = elemList[a];
+			for (let a = 0; a < keys.length; a++) {
+				const elem = elemList[a];
 
 				if(elem === void 0){
 					EM.append(keys[a]);
@@ -1375,7 +1375,7 @@ class ElementManipulatorProxy{
 				}
 
 				if(instance[keys[a]] !== elem.model){
-					var newElem = EM.createElement(keys[a]);
+					const newElem = EM.createElement(keys[a]);
 					EM.parentNode.replaceChild(newElem, elem);
 
 					if(EM.elements !== void 0)
@@ -1385,11 +1385,11 @@ class ElementManipulatorProxy{
 		}
 	}
 	getElement_RP(instance, prop){
-		var list = this.list;
-		var keys = instance._list;
+		const { list } = this;
+		const keys = instance._list;
 
-		var got = [];
-		for (var i = 0; i < list.length; i++) {
+		const got = [];
+		for (let i = 0; i < list.length; i++) {
 			var val;
 			if(typeof this[prop] === 'object')
 				val = list[i].elementRef.get(instance[prop]);
@@ -1402,11 +1402,11 @@ class ElementManipulatorProxy{
 		return got;
 	}
 	getElement_RL(instance, index){
-		var list = this.list;
-		var got = [];
+		const { list } = this;
+		const got = [];
 
-		for (var i = 0; i < list.length; i++) {
-			var EM = list[i];
+		for (let i = 0; i < list.length; i++) {
+			const EM = list[i];
 			var val;
 
 			if(index.constructor === Number){
@@ -1425,68 +1425,68 @@ class ElementManipulatorProxy{
 	}
 
 	$el(selector){
-		var list = [];
-		var $EMs = this.list;
-		for (var i = 0; i < $EMs.length; i++) {
-			var em = $EMs[i];
+		const list = [];
+		const $EMs = this.list;
+		for (let i = 0; i < $EMs.length; i++) {
+			const em = $EMs[i];
 			list.push.apply(list, queryElements((em.parentChilds || em.elements), selector));
 		}
 		return $(list);
 	}
 
 	hardRefresh(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].hardRefresh.apply(list[i], arguments);
 	}
 	update(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].update.apply(list[i], arguments);
 	}
 	move(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].move.apply(list[i], arguments);
 	}
 	swap(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].swap.apply(list[i], arguments);
 	}
 	remove(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].remove.apply(list[i], arguments);
 	}
 	removeRange(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].removeRange.apply(list[i], arguments);
 	}
 	clear(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].clear.apply(list[i], arguments);
 	}
 	insertAfter(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].insertAfter.apply(list[i], arguments);
 	}
 	prepend(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].prepend.apply(list[i], arguments);
 	}
 	append(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].append.apply(list[i], arguments);
 	}
 	reverse(){
-		var list = this.list;
-		for (var i = 0; i < list.length; i++)
+		const { list } = this;
+		for (let i = 0; i < list.length; i++)
 			list[i].reverse.apply(list[i], arguments);
 	}
 }
@@ -1496,8 +1496,8 @@ internal.EMP = ElementManipulatorProxy;
 
 function RE_restoreBindedList(modelRoot, lists){
 	// lists [paths, backup]
-	for (var i = 0; i < lists.length; i++) {
-		var bindList = RE_getBindedList(modelRoot, lists[i][0]);
+	for (let i = 0; i < lists.length; i++) {
+		const bindList = RE_getBindedList(modelRoot, lists[i][0]);
 		if(bindList === void 0)
 			continue;
 
@@ -1510,7 +1510,7 @@ function RE_getBindedList(modelRoot, binded){
 	if(binded.length === 1)
 		return modelRoot.sf$bindedKey[binded[0]];
 
-	var check = deepProperty(modelRoot, binded.slice(0, -1));
+	const check = deepProperty(modelRoot, binded.slice(0, -1));
 	if(check === void 0 || check.sf$bindedKey === void 0)
 		return;
 

--- a/src/sf-model/repeated-list.js
+++ b/src/sf-model/repeated-list.js
@@ -1390,7 +1390,7 @@ class ElementManipulatorProxy{
 
 		const got = [];
 		for (let i = 0; i < list.length; i++) {
-			var val;
+			let val;
 			if(typeof this[prop] === 'object')
 				val = list[i].elementRef.get(instance[prop]);
 			else
@@ -1407,7 +1407,7 @@ class ElementManipulatorProxy{
 
 		for (let i = 0; i < list.length; i++) {
 			const EM = list[i];
-			var val;
+			let val;
 
 			if(index.constructor === Number){
 				if(typeof instance[index] !== 'object')

--- a/src/sf-model/template.js
+++ b/src/sf-model/template.js
@@ -307,7 +307,7 @@ sf.async = function(mode){
 }
 
 var animFrameMode = false;
-var syntheticTemplate = internal.model.syntheticTemplate = function(element, template, property, item, asyncing){
+const syntheticTemplate = internal.model.syntheticTemplate = function(element, template, property, item, asyncing){
 	if(property !== void 0){
 		var changes = (template.modelRef && template.modelRef[property]) || template.modelRefRoot[property];
 		if(!changes || changes.length === 0){
@@ -448,4 +448,4 @@ var syntheticTemplate = internal.model.syntheticTemplate = function(element, tem
 	}
 
 	return haveChanges;
-}
+};

--- a/src/sf-model/template.js
+++ b/src/sf-model/template.js
@@ -1,8 +1,8 @@
 function elseIfHandle(else_, arg){
-	var elseIf = else_.elseIf;
+	const { elseIf } = else_;
 
 	// Else if
-	for (var i = 0; i < elseIf.length; i++) {
+	for (let i = 0; i < elseIf.length; i++) {
 		// Check the condition
 		if(!elseIf[i][0](arg[0], arg[1], _escapeParse))
 			continue;
@@ -19,10 +19,10 @@ function elseIfHandle(else_, arg){
 }
 
 // ==== Template parser ====
-var templateParser_regex = /{{%=([0-9]+)%/g;
-var templateParser_regex_split = /{{%=[0-9]+%/g;
-var REF_DIRECT = 0, REF_IF = 1, REF_EXEC = 2;
-var templateExec = function(parse, item, atIndex, parsed, repeatListIndex){
+const templateParser_regex = /{{%=([0-9]+)%/g;
+const templateParser_regex_split = /{{%=[0-9]+%/g;
+const REF_DIRECT = 0, REF_IF = 1, REF_EXEC = 2;
+const templateExec = function(parse, item, atIndex, parsed, repeatListIndex){
 	if(parse.length === 0) return parse;
 	var temp;
 
@@ -30,12 +30,12 @@ var templateExec = function(parse, item, atIndex, parsed, repeatListIndex){
 		parsed = new Array(parse.length);
 
 	// Get or evaluate static or dynamic data
-	for (var i = 0, n = parse.length; i < n; i++) {
+	for (let i = 0, n = parse.length; i < n; i++) {
 		if(atIndex !== void 0 && atIndex.includes(i) === false)
 			continue;
 
-		var ref = parse[i];
-		var arg = ref.data;
+		const ref = parse[i];
+		const arg = ref.data;
 		arg[0] = item; //7ms
 
 		try{
@@ -94,8 +94,8 @@ var templateExec = function(parse, item, atIndex, parsed, repeatListIndex){
 	return parsed;
 }
 function parserForAttribute(current, ref, item, modelRef, parsed, changesReference, rootHandler, template){
-	for(var a = 0; a < ref.length; a++){
-		var refB = ref[a];
+	for(let a = 0; a < ref.length; a++){
+		const refB = ref[a];
 
 		// Pass to event handler
 		if(refB.event){
@@ -105,7 +105,7 @@ function parserForAttribute(current, ref, item, modelRef, parsed, changesReferen
 			continue;
 		}
 
-		var isValueInput = (refB.name === 'value' && (current.tagName === 'TEXTAREA' ||
+		const isValueInput = (refB.name === 'value' && (current.tagName === 'TEXTAREA' ||
 			(current.tagName === 'INPUT' && sfRegex.inputAttributeType.test(current.type) === false)
 		));
 
@@ -146,11 +146,11 @@ function parserForAttribute(current, ref, item, modelRef, parsed, changesReferen
 	}
 }
 
-var templateParser = internal.model.templateParser = function(template, item, original, modelRef, rootHandler, copy, repeatListIndex){
+const templateParser = internal.model.templateParser = function(template, item, original, modelRef, rootHandler, copy, repeatListIndex){
 	processingElement = template.html;
 
-	var html = original === true ? template.html : template.html.cloneNode(true);
-	var addresses = template.addresses;
+	let html = original === true ? template.html : template.html.cloneNode(true);
+	const { addresses } = template;
 
 	try{
 		var parsed = templateExec(template.parse, item, void 0, void 0, repeatListIndex);  //18ms
@@ -168,13 +168,13 @@ var templateParser = internal.model.templateParser = function(template, item, or
 		html.sf$repeatListIndex = repeatListIndex;
 
 	if(copy !== void 0){
-		var childs = html.childNodes;
+		const childs = html.childNodes;
 		for (var i = 0, n = childs.length; i < n; i++) {
 			copy.appendChild(childs[0]);
 		}
 
 		// Assign attributes
-		var attr = html.attributes;
+		const attr = html.attributes;
 		for (var i = 0; i < attr.length; i++) {
 			copy.setAttribute(attr[i].name, attr[i].value);
 		}
@@ -182,15 +182,15 @@ var templateParser = internal.model.templateParser = function(template, item, or
 		html = copy;
 	}
 
-	var changesReference = [];
-	var pendingInsert = [];
+	const changesReference = [];
+	const pendingInsert = [];
 
 	changesReference.parsed = parsed;
 
 	// Find element where the data belongs to
 	for (var i = 0; i < addresses.length; i++) {
 		var ref = addresses[i];
-		var current = $.childIndexes(ref.address, html); //26ms
+		const current = $.childIndexes(ref.address, html); //26ms
 
 		// Modify element attributes
 		if(ref.nodeType === 1){
@@ -200,11 +200,11 @@ var templateParser = internal.model.templateParser = function(template, item, or
 
 		// Replace text node
 		if(ref.nodeType === 3){
-			var refA = current;
+			const refA = current;
 
 			changesReference.push({
 				textContent:refA,
-				ref:ref
+				ref
 			});
 
 			if(ref.direct !== void 0){
@@ -219,7 +219,7 @@ var templateParser = internal.model.templateParser = function(template, item, or
 
 		// Replace dynamic node
 		if(ref.nodeType === -1){
-			var cRef = {
+			const cRef = {
 				dynamicFlag:current,
 				direct:ref.parse_index,
 				parentNode:current.parentNode,
@@ -249,7 +249,7 @@ var templateParser = internal.model.templateParser = function(template, item, or
 	// Run the pending element
 	for (var i = 0; i < pendingInsert.length; i++) {
 		var ref = pendingInsert[i];
-		var tDOM = parsed[ref.direct];
+		let tDOM = parsed[ref.direct];
 
 		// Check if it's an HTMLElement
 		if(tDOM.nodeType === 1){
@@ -267,8 +267,8 @@ var templateParser = internal.model.templateParser = function(template, item, or
 	if(template.specialElement){
 		if(template.specialElement.input){
 			// Process element for input bind
-			var specialInput = template.specialElement.input;
-			var specialInput_ = new Array(specialInput.length);
+			const specialInput = template.specialElement.input;
+			const specialInput_ = new Array(specialInput.length);
 			for (var i = 0; i < specialInput.length; i++) {
 				var ref = specialInput[i];
 				specialInput_[i] = {
@@ -283,8 +283,8 @@ var templateParser = internal.model.templateParser = function(template, item, or
 
 		if(template.specialElement.repeat){
 			// Process element for sf-repeat-this
-			var specialRepeat = template.specialElement.repeat;
-			var specialRepeat_ = new Array(specialRepeat.length);
+			const specialRepeat = template.specialElement.repeat;
+			const specialRepeat_ = new Array(specialRepeat.length);
 			for (var i = 0; i < specialRepeat.length; i++) {
 				var ref = specialRepeat[i];
 				specialRepeat_[i] = {
@@ -312,7 +312,7 @@ var syntheticTemplate = internal.model.syntheticTemplate = function(element, tem
 		var changes = (template.modelRef && template.modelRef[property]) || template.modelRefRoot[property];
 		if(!changes || changes.length === 0){
 			console.log(element, template, property, item);
-			console.error("Failed to run syntheticTemplate because property '"+property+"' is not observed");
+			console.error(`Failed to run syntheticTemplate because property '${property}' is not observed`);
 			return false;
 		}
 	}
@@ -323,13 +323,13 @@ var syntheticTemplate = internal.model.syntheticTemplate = function(element, tem
 		var changes = void 0;
 	}
 
-	var changesReference = element.sf$elementReferences;
+	const changesReference = element.sf$elementReferences;
 
 	if(changesReference.parsed === void 0)
 		changesReference.parsed = new Array(template.parse.length);
 
-	var parsed = changesReference.parsed;
-	var repeatListIndex = element.sf$repeatListIndex;
+	const { parsed } = changesReference;
+	const repeatListIndex = element.sf$repeatListIndex;
 
 	if(!asyncing)
 		templateExec(template.parse, item, changes, parsed, repeatListIndex);
@@ -348,15 +348,15 @@ var syntheticTemplate = internal.model.syntheticTemplate = function(element, tem
 		return;
 	}
 
-	var haveChanges = false, temp;
-	for (var i = 0; i < changesReference.length; i++) {
-		var cRef = changesReference[i];
+	let haveChanges = false, temp;
+	for (let i = 0; i < changesReference.length; i++) {
+		const cRef = changesReference[i];
 
 		if(cRef.dynamicFlag !== void 0){ // Dynamic data
 			if(parsed[cRef.direct] !== void 0){
-				var tDOM = Array.from($.parseElement(parsed[cRef.direct]));
-				var currentDOM = $.prevAll(cRef.dynamicFlag, cRef.startFlag);
-				var notExist = false;
+				const tDOM = Array.from($.parseElement(parsed[cRef.direct]));
+				const currentDOM = $.prevAll(cRef.dynamicFlag, cRef.startFlag);
+				let notExist = false;
 
 				// Replace if exist, skip if similar
 				for (var a = tDOM.length-1; a >= 0; a--) {
@@ -401,7 +401,7 @@ var syntheticTemplate = internal.model.syntheticTemplate = function(element, tem
 				temp = parsed[cRef.ref.direct];
 				if(cRef.textContent.textContent === temp) continue;
 
-				var ref_ = cRef.textContent;
+				const ref_ = cRef.textContent;
 				// Remove old element if exist
 				if(ref_.sf$haveChilds === true){
 					while(ref_.previousSibling && ref_.previousSibling.sf$childRoot === ref_)

--- a/src/sf-polyfill.js
+++ b/src/sf-polyfill.js
@@ -1,7 +1,7 @@
 if(Element.prototype.remove === void 0 || CharacterData.prototype.remove === void 0 || DocumentType.prototype.remove === void 0){
 	(function(){
-		var arr = [Element.prototype, CharacterData.prototype, DocumentType.prototype];
-		for (var i = 0; i < arr.length; i++) {
+		const arr = [Element.prototype, CharacterData.prototype, DocumentType.prototype];
+		for (let i = 0; i < arr.length; i++) {
 			if(arr[i].hasOwnProperty('remove'))
 				return;
 
@@ -18,7 +18,7 @@ if(Element.prototype.matches === void 0)
 
 if(Element.prototype.closest === void 0){
 	Element.prototype.closest = function(selector){
-		var elem = this;
+		let elem = this;
 		do {
 			if(elem === document)
 				return null;

--- a/src/sf-request.js
+++ b/src/sf-request.js
@@ -1,18 +1,10 @@
-$.get = function(url, data, options, callback) {
-	return custom('GET', url, data, options, callback);
-}
-$.post = function(url, data, options, callback) {
-	return custom('POST', url, data, options, callback);
-}
-$.getJSON = function(url, data, options, callback) {
-	return custom('getJSON', url, data, options, callback);
-}
-$.postJSON = function(url, data, options, callback) {
-	return custom('postJSON', url, data, options, callback);
-}
+$.get = (url, data, options, callback) => custom('GET', url, data, options, callback)
+$.post = (url, data, options, callback) => custom('POST', url, data, options, callback)
+$.getJSON = (url, data, options, callback) => custom('getJSON', url, data, options, callback)
+$.postJSON = (url, data, options, callback) => custom('postJSON', url, data, options, callback)
 
 sf.request = custom;
-var statusCode = sf.request.statusCode = {};
+const statusCode = sf.request.statusCode = {};
 sf.request.onerror = null;
 sf.request.onsuccess = null;
 
@@ -44,7 +36,7 @@ function custom(method, url, data, options, callback){
 }
 
 function request(method, url, data, options, callback){
-	var xhr = new XMLHttpRequest();
+	const xhr = new XMLHttpRequest();
 	options.beforeOpen && options.beforeOpen(xhr);
 
 	if(method === 'GET' || method === 'HEAD' || method === 'OPTIONS' || method === 'DELETE'){
@@ -64,20 +56,20 @@ function request(method, url, data, options, callback){
 			data = JSON.stringify(data);
 		}
 		else{
-			var temp = data;
+			const temp = data;
 
 			data = new FormData();
 			for(var name in temp){
-				var val = temp[name];
+				const val = temp[name];
 
 				if(val.constructor === Array){
-					for (var i = 0; i < val.length; i++)
+					for (let i = 0; i < val.length; i++)
 						data.append(name+'[]', val[i]);
 					continue;
 				}
 
 				if(val.constructor === Object){
-					for(var valKey in val)
+					for(let valKey in val)
 						data.append(name+'['+valKey+']', val[valKey]);
 					continue;
 				}
@@ -120,7 +112,7 @@ function request(method, url, data, options, callback){
 	xhr.onload = function(){
 		if((xhr.status >= 200 && xhr.status < 300) || xhr.status === 0){
 			if(options.receiveType === 'JSON'){
-				var parsed = void 0;
+				let parsed = void 0;
 				try{
 					parsed = JSON.parse(xhr.responseText);
 				}catch(e){
@@ -159,17 +151,17 @@ function request(method, url, data, options, callback){
 }
 
 function serializeQuery(params) {
-	var keys = [];
-	for(var key in params){
-		var val = params[key];
+	const keys = [];
+	for(let key in params){
+		const val = params[key];
 		if (val.constructor === Array){
-			for (var i = 0; i < val.length; i++)
+			for (let i = 0; i < val.length; i++)
 				keys.push(key+"[]="+encodeURIComponent(val[i]));
 			continue;
 		}
 
 		if(val.constructor === Object){
-			for(var valKey in val)
+			for(let valKey in val)
 				keys.push(key+"["+valKey+"]="+encodeURIComponent(val[valKey]));
 			continue;
 		}

--- a/src/sf-space.js
+++ b/src/sf-space.js
@@ -1,18 +1,16 @@
 // ToDo: component list on registrar[2] still using same reference
 
-sf.space = function(namespace, options){
-	return new Space(namespace, options);
-};
+sf.space = (namespace, options)=> new Space(namespace, options);
 
 // { name:{ default:{}, id:{}, ... } }
 sf.space.list = {};
 function getNamespace(name, id){
-	var scope = sf.space.list[name];
+	let scope = sf.space.list[name];
 	if(scope === void 0)
 		scope = sf.space.list[name] = {};
 
 	if(scope[id] === void 0){
-		var ref = scope.default;
+		let ref = scope.default;
 		if(ref === void 0){
 			ref = scope.default = createRoot_({}, {});
 
@@ -28,7 +26,7 @@ function getNamespace(name, id){
 
 function createRoot_(modelFunc, registered){
 	var root_ = function(scope){
-		var temp = root_.registered[scope];
+		let temp = root_.registered[scope];
 		if(temp) return temp[2];
 
 		temp = root_.root;
@@ -46,7 +44,7 @@ function createRoot_(modelFunc, registered){
 	root_.root = {};
 	root_.modelFunc = modelFunc;
 	root_.registered = registered;
-	var domList = root_.domList = [];
+	const domList = root_.domList = [];
 
 	return root_;
 }
@@ -56,11 +54,11 @@ if(window.sf$proxy)
 else
 	internal.space = {
 		empty:true,
-		initComponent:function(root, tagName, elem, $item, asScope){
+		initComponent(root, tagName, elem, $item, asScope){
 			sf.component.new(tagName, elem, $item, root.constructor === Function ? root : root.sf$space, asScope);
 		},
-		initModel:function(root, elem){
-			var name = elem.getAttribute('name');
+		initModel(root, elem){
+			const name = elem.getAttribute('name');
 
 			// Pending if model handler was not loaded
 			if(root.sf$space.modelFunc[name] === void 0)
@@ -98,7 +96,7 @@ class Space{
 	}
 
 	createHTML(index){
-		var that = this;
+		const that = this;
 		return $(window.templates[this.templatePath]
 			.replace(/<sf-space(.*?)(?:|="(.*?)")>/, function(full, namespace, index_){
 				if(index_ && isNaN(index_) === false)
@@ -106,9 +104,9 @@ class Space{
 
 				index = index || index_ || false;
 				if(index)
-					index = '="'+index+'"';
+					index = `="${index}"`;
 
-				return '<sf-space '+that.namespace+'>';
+				return `<sf-space ${that.namespace}>`;
 			}))[0];
 	}
 
@@ -118,7 +116,7 @@ class Space{
 }
 
 ;(function(){
-	var self = Space.prototype;
+	const self = Space.prototype;
 	self.model = function(name, options, func){
 		if(options !== void 0){
 			if(options.constructor === Function)
@@ -127,12 +125,12 @@ class Space{
 				internal.modelInherit[name] = options.extend;
 			}
 
-			var old = this.default.modelFunc[name];
+			const old = this.default.modelFunc[name];
 			this.default.modelFunc[name] = func;
 
 			if(old !== void 0 && old.constructor === Array)
-				for (var i = 0; i < old.length; i++){
-					var arg = old[i];
+				for (let i = 0; i < old.length; i++){
+					const arg = old[i];
 					sf.model.init(arg[0], arg[1], arg[2]);
 				}
 
@@ -185,8 +183,8 @@ class SFSpace extends HTMLElement {
 		forProxying.internalSpaceEmpty = internal.space.empty = false;
 
 		// Extract namespace name
-		for(var i=0, n=this.attributes.length; i < n; i++){
-			var name = this.attributes[i].name
+		for(let i=0, n=this.attributes.length; i < n; i++){
+			var { name } = this.attributes[i]
 			if(name === 'class' || name === 'style' || name === 'id')
 				continue;
 
@@ -202,9 +200,9 @@ class SFSpace extends HTMLElement {
 		this.sf$space.domList.push(this);
 	}
 	disconnectedCallback(){
-		var that = this;
-		var destroy = function(){
-			var i = that.sf$space.domList.indexOf(that);
+		const that = this;
+		const destroy = function(){
+			const i = that.sf$space.domList.indexOf(that);
 			if(i !== -1)
 				that.sf$space.domList.splice(i, 1);
 		}

--- a/src/sf-space.js
+++ b/src/sf-space.js
@@ -25,7 +25,7 @@ function getNamespace(name, id){
 }
 
 function createRoot_(modelFunc, registered){
-	var root_ = function(scope){
+	const root_ = function(scope){
 		let temp = root_.registered[scope];
 		if(temp) return temp[2];
 
@@ -39,7 +39,7 @@ function createRoot_(modelFunc, registered){
 		}
 
 		return temp[scope];
-	}
+	};
 
 	root_.root = {};
 	root_.modelFunc = modelFunc;

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -1,5 +1,5 @@
 ;(function(){
-var self = sf.url = function(){
+const self = sf.url = function(){
 	// Hashes
 	let hashes_ = '';
 	for(let keys in hashes){
@@ -10,9 +10,9 @@ var self = sf.url = function(){
 	const data_ = `|${self.data.join('|')}`;
 
 	return self.paths + hashes_ + (data_.length !== 1 ? data_ : '');
-}
+};
 
-var hashes = self.hashes = {};
+let hashes = self.hashes = {};
 self.data = [];
 self.paths = '/';
 

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -1,13 +1,13 @@
 ;(function(){
 var self = sf.url = function(){
 	// Hashes
-	var hashes_ = '';
-	for(var keys in hashes){
+	let hashes_ = '';
+	for(let keys in hashes){
 		if(hashes[keys] === '/') continue;
-		hashes_ += '#'+keys+hashes[keys];
+		hashes_ += `#${keys}${hashes[keys]}`;
 	}
 
-	var data_ = '|'+self.data.join('|');
+	const data_ = `|${self.data.join('|')}`;
 
 	return self.paths + hashes_ + (data_.length !== 1 ? data_ : '');
 }
@@ -40,14 +40,14 @@ self.get = function(name, index){
 
 self.parse = function(url){
 	if(url !== void 0){
-		var data = {hashes:{}};
+		const data = {hashes:{}};
 
 		data.data = url.split('|');
 		var hashes_ = data.data.shift().split('#');
 
 		for (var i = 1; i < hashes_.length; i++) {
 			var temp = hashes_[i].split('/');
-			data.hashes[temp.shift()] = '/'+temp.join('/');
+			data.hashes[temp.shift()] = `/${temp.join('/')}`;
 		}
 
 		// Paths
@@ -61,7 +61,7 @@ self.parse = function(url){
 	hashes = self.hashes = {};
 	for (var i = 1; i < hashes_.length; i++) {
 		var temp = hashes_[i].split('/');
-		hashes[temp.shift()] = '/'+temp.join('/');
+		hashes[temp.shift()] = `/${temp.join('/')}`;
 	}
 
 	// Paths

--- a/src/sf-views.js
+++ b/src/sf-views.js
@@ -1,17 +1,17 @@
 ;(function(){
-var gEval = routerEval;
+const gEval = routerEval;
 routerEval = void 0; // Avoid this function being invoked out of scope
 
-var rejectResponse = /<html/;
+const rejectResponse = /<html/;
 
 // Save reference
-var slash = '/';
+const slash = '/';
 
-var routingError = false;
-var routeDirection = 1;
-var historyIndex = (window.history.state || 1);
+let routingError = false;
+let routeDirection = 1;
+let historyIndex = (window.history.state || 1);
 
-var disableHistoryPush = false;
+let disableHistoryPush = false;
 
 window.addEventListener('popstate', function(ev){
 	// Don't continue if the last routing was error
@@ -39,21 +39,21 @@ window.addEventListener('popstate', function(ev){
 	disableHistoryPush = false;
 }, false);
 
-var cachedURL = {};
+const cachedURL = {};
 
 internal.router = {};
 internal.router.parseRoutes = function(obj_, selectorList){
-	var routes = [];
-	var pattern = /\/:([^/]+)/g;
-    var knownKeys = /^(path|url|template|templateURL|html|on|routes|beforeRoute|defaultData|cache)$/;
+	const routes = [];
+	const pattern = /\/:([^/]+)/g;
+    const knownKeys = /^(path|url|template|templateURL|html|on|routes|beforeRoute|defaultData|cache)$/;
 
 	function addRoutes(obj, addition, selector, parent){
 		if(selector !== '')
 			selector += ' ';
 
-		for(var i = 0; i < obj.length; i++){
-            var ref = obj[i];
-			var current = addition+ref.path;
+		for(let i = 0; i < obj.length; i++){
+            const ref = obj[i];
+			let current = addition+ref.path;
 
 			if(ref.routes !== void 0)
 				addRoutes(ref.routes, current, selector, parent);
@@ -61,11 +61,11 @@ internal.router.parseRoutes = function(obj_, selectorList){
 			current = current.split('//').join('/');
 
 			var keys = [];
-			var regex = current.replace(pattern, function(full, match){
+			const regex = current.replace(pattern, function(full, match){
 				keys.push(match);
 				return '/([^/]+)';
 			});
-			var route = RegExp('^' + regex + '$');
+			const route = RegExp(`^${regex}$`);
 
 			if(ref.url !== void 0)
 				route.url = ref.url;
@@ -78,11 +78,11 @@ internal.router.parseRoutes = function(obj_, selectorList){
 
 			else if(ref.html !== void 0){
 				// Create new element
-				var dom = route.html = document.createElement('sf-page-view');
+				const dom = route.html = document.createElement('sf-page-view');
 				internal.component.skip = true;
 
 				if(ref.html.constructor === String){
-					route.html = sf.dom.parseElement('<template>'+ref.html+'</template>', true)[0];
+					route.html = sf.dom.parseElement(`<template>${ref.html}</template>`, true)[0];
 					internal.component.skip = false;
 				}
 				else dom.appendChild(ref.html);
@@ -113,7 +113,7 @@ internal.router.parseRoutes = function(obj_, selectorList){
 			if(ref.cache)
 				route.cache = true;
 
-			var hasChild = [];
+			const hasChild = [];
 
 			for(var keys in ref) {
                 if(knownKeys.test(keys))
@@ -141,15 +141,15 @@ internal.router.parseRoutes = function(obj_, selectorList){
 }
 
 internal.router.findRoute = function(url){
-	for(var i=0; i<this.length; i++){
-		var found = url.match(this[i]);
+	for(let i=0; i<this.length; i++){
+		const found = url.match(this[i]);
 		if(found !== null){
-			var keys = this[i].keys;
+			const { keys } = this[i];
 			if(keys !== void 0){
-				var data = this[i].data = {};
+				const data = this[i].data = {};
 				found.shift();
 
-				for (var a = 0; a < keys.length; a++) {
+				for (let a = 0; a < keys.length; a++) {
 					data[keys[a]] = found[a];
 				}
 			}
@@ -165,12 +165,12 @@ var self = sf.views = function View(selector, name){
 	if(name === void 0)
 		name = slash;
 
-	var self = this;
+	const self = this;
 
 	if(name)
 		sf.views.list[name] = self;
 
-	var pendingAutoRoute = false;
+	let pendingAutoRoute = false;
 
 	// Init current URL as current View Path
 	if(name === slash)
@@ -182,8 +182,8 @@ var self = sf.views = function View(selector, name){
 		pendingAutoRoute = true;
 	}
 
-	var initialized = false;
-	var firstRouted = false;
+	let initialized = false;
+	let firstRouted = false;
 
 	self.lastPath = '/';
 	self.lastDOM = null;
@@ -193,11 +193,11 @@ var self = sf.views = function View(selector, name){
 
 	self.maxCache = 4;
 	function removeOldCache(current){
-		var parent = current.parentNode;
+		const parent = current.parentNode;
 		if(parent.sf$cachedDOM === void 0)
 			parent.sf$cachedDOM = [];
 
-		var i = parent.sf$cachedDOM.indexOf(current);
+		const i = parent.sf$cachedDOM.indexOf(current);
 		if(i === -1)
 			parent.sf$cachedDOM.push(current);
 		else
@@ -207,9 +207,9 @@ var self = sf.views = function View(selector, name){
 			parent.sf$cachedDOM.shift().remove();
 	}
 
-	var rootDOM = self.rootDOM = {};
+	let rootDOM = self.rootDOM = {};
 	function getSelector(selector_, isChild, currentPath){
-		var DOM = (isChild || (rootDOM.isConnected ? rootDOM : document.body)).getElementsByTagName(selector_ || selector);
+		let DOM = (isChild || (rootDOM.isConnected ? rootDOM : document.body)).getElementsByTagName(selector_ || selector);
 		if(DOM.length === 0) return false;
 
 		DOM = DOM[0];
@@ -224,7 +224,7 @@ var self = sf.views = function View(selector, name){
 		// 	selector = selector_;
 
 		// Create listener for link click
-		var temp = null;
+		let temp = null;
 
 		// Bring the content to an sf-page-view element
 		if(DOM.childNodes.length !== 0){
@@ -234,7 +234,7 @@ var self = sf.views = function View(selector, name){
 				temp = document.createElement('sf-page-view');
 				DOM.insertBefore(temp, DOM.firstChild);
 
-				for (var i = 1, n = DOM.childNodes.length; i < n; i++) {
+				for (let i = 1, n = DOM.childNodes.length; i < n; i++) {
 					temp.appendChild(DOM.childNodes[1]);
 				}
 
@@ -256,13 +256,13 @@ var self = sf.views = function View(selector, name){
 		return DOM;
 	}
 
-    var selectorList = [selector];
+    const selectorList = [selector];
 	var routes = self.routes = [];
 	routes.findRoute = internal.router.findRoute;
 
 	internal.router.enabled = true;
 
-	var onEvent = {
+	const onEvent = {
 		'start':[],
 		'finish':[],
 		'loading':[],
@@ -273,7 +273,7 @@ var self = sf.views = function View(selector, name){
 	self.on = function(event, func){
 		if(event.includes(' ')){
 			event = event.split(' ');
-			for (var i = 0; i < event.length; i++) {
+			for (let i = 0; i < event.length; i++) {
 				self.on(event[i], func);
 			}
 
@@ -281,7 +281,7 @@ var self = sf.views = function View(selector, name){
 		}
 
 		if(onEvent[event] === void 0)
-			return console.error("Event '"+event+"' was not exist");
+			return console.error(`Event '${event}' was not exist`);
 
 		if(onEvent[event].includes(func) === false)
 			onEvent[event].push(func);
@@ -300,7 +300,7 @@ var self = sf.views = function View(selector, name){
 		}
 
 		if(onEvent[event] === void 0)
-			return console.error("Event '"+event+"' was not exist");
+			return console.error(`Event '${event}' was not exist`);
 
 		if(func === void 0){
 			onEvent[event].length = 0;
@@ -346,12 +346,12 @@ var self = sf.views = function View(selector, name){
 		return self;
 	}
 
-	var RouterLoading = false; // xhr reference if the router still loading
+	let RouterLoading = false; // xhr reference if the router still loading
 
 	var collection = null;
 	function findRelatedElement(currentURL){
-		var found = [];
-		for (var i = 0; i < collection.length; i++) {
+		const found = [];
+		for (let i = 0; i < collection.length; i++) {
 			if(currentURL.indexOf(collection[i].routePath) === 0)
 				found.push(collection[i]);
 		}
@@ -360,7 +360,7 @@ var self = sf.views = function View(selector, name){
 	}
 
 	function findCachedURL(currentURL){
-		for (var i = collection.length-1; i >= 0; i--) { // Search from deep view first
+		for (let i = collection.length-1; i >= 0; i--) { // Search from deep view first
 			if(currentURL === collection[i].routePath)
 				return collection[i];
 		}
@@ -369,14 +369,14 @@ var self = sf.views = function View(selector, name){
 	}
 
 	function routeErrorPassEvent(statusCode, data){
-		var ref = onEvent.error;
+		const ref = onEvent.error;
 
 		if(ref.length === 0){
 			console.error('Unhandled router error:', statusCode, data);
 			return;
 		}
 
-		for (var i = 0; i < ref.length; i++) {
+		for (let i = 0; i < ref.length; i++) {
 			ref[i](statusCode, data);
 		}
 	}
@@ -391,11 +391,11 @@ var self = sf.views = function View(selector, name){
 		window.history.go(routeDirection * -1);
 	}
 
-	var pageViewNodeName = 'SF-PAGE-VIEW';
+	const pageViewNodeName = 'SF-PAGE-VIEW';
 	function toBeShowed(element, event, path, data){
-		var relatedPage = [element];
+		const relatedPage = [element];
 
-		var parent = element.parentNode;
+		let parent = element.parentNode;
 		while(parent !== rootDOM && parent !== null){
 			if(parent.nodeName === pageViewNodeName)
 				relatedPage.unshift(parent);
@@ -403,8 +403,8 @@ var self = sf.views = function View(selector, name){
 			parent = parent.parentNode;
 		}
 
-		var lastSibling = null;
-		var parentSimilarity = null;
+		let lastSibling = null;
+		let parentSimilarity = null;
 
 		for (var i = 0; i < self.relatedDOM.length; i++) {
 			if(relatedPage.includes(self.relatedDOM[i]) === false){
@@ -417,7 +417,7 @@ var self = sf.views = function View(selector, name){
 			}
 		}
 
-		var showedSibling = null;
+		let showedSibling = null;
 		for (var i = 0; i < relatedPage.length; i++) {
 			if(showedSibling === null && relatedPage[i].parentNode === parentSimilarity)
 				showedSibling = relatedPage[i];
@@ -434,7 +434,7 @@ var self = sf.views = function View(selector, name){
 	}
 
 	self.removeRoute = function(path){
-		var found = routes.findRoute(path);
+		const found = routes.findRoute(path);
 		if(found === false)
 			return;
 
@@ -450,7 +450,7 @@ var self = sf.views = function View(selector, name){
 		routes.splice(i, 1);
 	}
 
-	var routeTotal = 0;
+	let routeTotal = 0;
 	self.goto = function(path, data, method, callback, _routeCount){
 		if(self.currentPath === path)
 			return;
@@ -479,7 +479,7 @@ var self = sf.views = function View(selector, name){
 			method = void 0;
 		}
 
-		var dynamicHTML = false;
+		let dynamicHTML = false;
 		if(data instanceof HTMLElement){
 			dynamicHTML = data;
 			data = void 0;
@@ -492,10 +492,10 @@ var self = sf.views = function View(selector, name){
 		pendingAutoRoute = false;
 
 		// Get template URL
-		var url = routes.findRoute(path);
+		const url = routes.findRoute(path);
 		if(!url){
 			return routeErrorPassEvent(404, {
-				path:path,
+				path,
 				message:"Path was not found"
 			});
 		}
@@ -519,7 +519,7 @@ var self = sf.views = function View(selector, name){
 				rootDOM = {};
 
 			if(getSelector() === false)
-				return console.error(name, "can't route to", path, "because element with selector '"+selector+"' was not found");
+				return console.error(name, "can't route to", path, `because element with selector '${selector}' was not found`);
 		}
 
 		// Abort other router loading if exist
@@ -531,14 +531,14 @@ var self = sf.views = function View(selector, name){
 		// Count all parent route
 		if(_routeCount === void 0){
 			routeTotal = 1;
-			var routeParent = url.parent;
+			let routeParent = url.parent;
 			while(routeParent !== void 0){
 				routeTotal++;
 				routeParent = routeParent.parent;
 			}
 		}
 
-		var currentData = self.data = url.data;
+		const currentData = self.data = url.data;
 
 		function insertLoadedElement(DOMReference, dom, pendingShowed){
 			dom.routerData = {};
@@ -550,7 +550,7 @@ var self = sf.views = function View(selector, name){
 			}
 
 			// Trigger loaded event
-			var rC = routeTotal + 1 - (_routeCount || 1);
+			const rC = routeTotal + 1 - (_routeCount || 1);
 			for (var i = 0; i < onEvent.loaded.length; i++) {
 				if(onEvent.loaded[i](rC, routeTotal, dom)) return;
 			}
@@ -559,7 +559,7 @@ var self = sf.views = function View(selector, name){
 			DOMReference.insertAdjacentElement('beforeend', dom);
 
 			if(self.dynamicScript !== false){
-				var scripts = dom.getElementsByTagName('script');
+				const scripts = dom.getElementsByTagName('script');
 				for (var i = 0; i < scripts.length; i++) {
 				    gEval(scripts[i].text);
 				}
@@ -567,7 +567,7 @@ var self = sf.views = function View(selector, name){
 
 			// Wait if there are some component that being initialized
 			// setTimeout(function(){
-				var tempDOM = self.currentDOM;
+				const tempDOM = self.currentDOM;
 				self.lastDOM = tempDOM;
 				self.currentDOM = dom;
 				self.currentPath = path;
@@ -610,7 +610,7 @@ var self = sf.views = function View(selector, name){
 			// });
 		}
 
-		var afterDOMLoaded = function(dom){
+		const afterDOMLoaded = function(dom){
 			if(url.selector || url.hasChild){
 				var selectorElement = dom.sf$viewSelector;
 
@@ -625,7 +625,7 @@ var self = sf.views = function View(selector, name){
 				var pendingShowed = [];
 				for (var i = 0; i < url.hasChild.length; i++) {
 					selectorElement[url.hasChild[i]] = getSelector(url.hasChild[i], dom, path);
-					var tempPageView = selectorElement[url.hasChild[i]].firstElementChild;
+					const tempPageView = selectorElement[url.hasChild[i]].firstElementChild;
 
 					if(tempPageView)
 						pendingShowed.unshift(tempPageView);
@@ -639,14 +639,14 @@ var self = sf.views = function View(selector, name){
 			if(url.selector === void 0)
 				var DOMReference = rootDOM;
 			else{ // Get element from selector
-				var selectorName = selectorList[url.selector];
+				const selectorName = selectorList[url.selector];
 				var DOMReference = null;
 
-				var last = findRelatedElement(path);
+				const last = findRelatedElement(path);
 
 				// Find current parent
 				for (var i = 0; i < last.length; i++) {
-					var found = last[i].sf$viewSelector;
+					const found = last[i].sf$viewSelector;
 					if(found === void 0 || found[selectorName] === void 0)
 						continue;
 
@@ -657,14 +657,14 @@ var self = sf.views = function View(selector, name){
 					if(url.parent === void 0){
 						dom.remove();
 						return routeError_({status:0}, {
-							path:path,
+							path,
 							target:dom,
 							message:"Parent element was not found while adding this element. Maybe it was disconnected from the DOM."
 						});
 					}
 					else{
 						// Try to load parent router first
-						var newPath = path.match(url.parent.forChild)[0];
+						const newPath = path.match(url.parent.forChild)[0];
 						return self.goto(newPath, false, method, function(parentNode){
 							DOMReference = parentNode.sf$viewSelector[selectorName];
 
@@ -677,15 +677,15 @@ var self = sf.views = function View(selector, name){
 							if(dom.routerData)
 								self.data = dom.routerData;
 							else if(dom.parentElement !== null){
-								var parent = dom.parentElement.closest('sf-page-view');
+								const parent = dom.parentElement.closest('sf-page-view');
 								if(parent !== null)
 									self.data = parent.routerData;
 							}
 
-							for (var i = 0; i < onEvent.finish.length; i++)
+							for (let i = 0; i < onEvent.finish.length; i++)
 								onEvent.finish[i](self.lastPath, path);
 
-							var defaultViewContent = dom.parentNode.defaultViewContent;
+							const { defaultViewContent } = dom.parentNode;
 							if(defaultViewContent !== void 0 && defaultViewContent.routePath !== path)
 								defaultViewContent.classList.remove('page-current');
 						}, _routeCount + 1 || 2);
@@ -699,7 +699,7 @@ var self = sf.views = function View(selector, name){
 			if(dom.routerData)
 				self.data = dom.routerData;
 			else if(dom.parentElement !== null){
-				var parent = dom.parentElement.closest('sf-page-view');
+				const parent = dom.parentElement.closest('sf-page-view');
 				if(parent !== null)
 					self.data = parent.routerData;
 			}
@@ -724,7 +724,7 @@ var self = sf.views = function View(selector, name){
 				return console.error("`window.templates` was not found");
 
 			// Create new element
-			url.html = sf.dom.parseElement('<template>'+window.templates[url.template+'.html']+'</template>', true)[0];
+			url.html = sf.dom.parseElement(`<template>${window.templates[url.template+'.html']}</template>`, true)[0];
 
 			if(hotReload)
 				url.template = url.template+'.html';
@@ -732,11 +732,11 @@ var self = sf.views = function View(selector, name){
 
 		if(url.html){
 			if(url.html.nodeName === 'TEMPLATE'){
-				var node = document.createElement('sf-page-view');
+				const node = document.createElement('sf-page-view');
 				node.classList.add('page-prepare');
 
-				var clone = url.html.cloneNode(true).content.childNodes;
-				for(var p=0, n=clone.length; p < n; p++){
+				const clone = url.html.cloneNode(true).content.childNodes;
+				for(let p=0, n=clone.length; p < n; p++){
 					node.insertBefore(clone[0], null);
 				}
 
@@ -748,9 +748,9 @@ var self = sf.views = function View(selector, name){
 			return true;
 		}
 
-		var thePath = (url.templateURL || url.url || path);
+		let thePath = (url.templateURL || url.url || path);
 		if(thePath[0] !== '/')
-			thePath = '/'+thePath;
+			thePath = `/${thePath}`;
 
 		for (var i = 0; i < onEvent.loading.length; i++)
 			if(onEvent.loading[i](_routeCount || 1, routeTotal)) return;
@@ -765,14 +765,14 @@ var self = sf.views = function View(selector, name){
 		.done(function(html_content){
 			if(rejectResponse.test(html_content)){
 				return routeError_({status:403}, {
-					path:path,
+					path,
 					requestURL:window.location.origin + thePath,
 					message:"Views request was received <html> while it was disallowed. Please check http response from Network Tab."
 				});
 			}
 
 			// Create new element
-			var dom = document.createElement('sf-page-view');
+			const dom = document.createElement('sf-page-view');
 			dom.classList.add('page-prepare');
 
 			var elements = sf.dom.parseElement(html_content);
@@ -783,7 +783,7 @@ var self = sf.views = function View(selector, name){
 			// Same as above but without the component initialization
 			if(url.templateURL !== void 0){
 				internal.component.skip = true;
-				var temp = document.createElement('sf-page-view');
+				const temp = document.createElement('sf-page-view');
 				temp.classList.add('page-prepare');
 
 				var elements = sf.dom.parseElement(html_content);
@@ -803,7 +803,7 @@ var self = sf.views = function View(selector, name){
 
 	// Use cache if exist
 	function tryCache(path){
-		var cachedDOM = false;
+		let cachedDOM = false;
 
 		function findDOM(dom){
 			if(dom === null)
@@ -813,8 +813,8 @@ var self = sf.views = function View(selector, name){
 			if(cachedDOM)
 				return true;
 
-			var childs = dom.children;
-			for (var i = 0; i < childs.length; i++) {
+			const childs = dom.children;
+			for (let i = 0; i < childs.length; i++) {
 				if(childs[i].routePath === path){
 					cachedDOM = childs[i];
 					// console.warn('cache found for', path, childs[i]);
@@ -843,7 +843,7 @@ var self = sf.views = function View(selector, name){
 		if(cachedDOM.routerData)
 			self.data = cachedDOM.routerData;
 		else if(cachedDOM.parentElement !== null){
-			var parent = cachedDOM.parentElement.closest('sf-page-view');
+			const parent = cachedDOM.parentElement.closest('sf-page-view');
 			if(parent !== null)
 				self.data = parent.routerData;
 		}
@@ -872,12 +872,12 @@ var self = sf.views = function View(selector, name){
 
 self.list = {};
 self.goto = function(url){
-	var parsed = sf.url.parse(url);
+	const parsed = sf.url.parse(url);
 	sf.url.data = parsed.data;
 
-	var views = self.list;
+	const views = self.list;
 
-	for(var list in self.list){
+	for(let list in self.list){
 		// For root path
 		if(list === slash){
 			if(views[slash].currentPath !== parsed.paths)
@@ -903,9 +903,9 @@ $(function(){
 	$.on(document.body, 'click', 'a[href]', function(ev){
 		ev.preventDefault();
 
-		var attr = this.getAttribute('href');
+		const attr = this.getAttribute('href');
 		if(attr[0] === '@'){ // ignore
-			var target = this.getAttribute('target');
+			const target = this.getAttribute('target');
 			if(target)
 				window.open(attr.slice(1), target);
 			else window.location = attr.slice(1);
@@ -913,7 +913,7 @@ $(function(){
 		}
 
 		// Make sure it's from current origin
-		var path = this.href.replace(window.location.origin, '');
+		const path = this.href.replace(window.location.origin, '');
 
 		// If it's different domain
 		if(path.includes('//')){

--- a/src/sf-views.js
+++ b/src/sf-views.js
@@ -161,7 +161,7 @@ internal.router.findRoute = function(url){
 	return false;
 }
 
-var self = sf.views = function View(selector, name){
+const self = sf.views = function View(selector, name){
 	if(name === void 0)
 		name = slash;
 
@@ -868,7 +868,7 @@ var self = sf.views = function View(selector, name){
 	}
 
 	return self;
-}
+};
 
 self.list = {};
 self.goto = function(url){

--- a/src/sf-virtual_scroll.js
+++ b/src/sf-virtual_scroll.js
@@ -3,9 +3,9 @@
 // day to make this working since using scroll event :(
 
 // ToDo: add sf$scrollPos and sf$heightPos
-var ElementManipulatorProxy = internal.EMP;
-var ElementManipulator = internal.EM;
-var VSM_Threshold = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
+const ElementManipulatorProxy = internal.EMP;
+const ElementManipulator = internal.EM;
+const VSM_Threshold = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
 
 class VirtualScrollManipulator {
 	waitMap = new Set();
@@ -33,18 +33,18 @@ class VirtualScrollManipulator {
 		root.appendChild(this.iBottom);
 		root.insertBefore(firstEl, this.iBottom);
 
-		var styled = window.getComputedStyle(firstEl);
+		const styled = window.getComputedStyle(firstEl);
 		this.elMargin = Number(styled.marginBottom.slice(0, -2)) + Number(styled.marginTop.slice(0, -2));
 
 		this.elMaxHeight = this.elHeight = firstEl.offsetHeight + this.elMargin;
 		firstEl.remove();
 
-		var that = this;
+		const that = this;
 		requestAnimationFrame(function(){
 			setTimeout(function(){
 				if(!root.isConnected) return; // Somewhat it's detached
 
-				var scroller = internal.findScrollerElement(root);
+				let scroller = internal.findScrollerElement(root);
 				if(scroller === null){
 					scroller = root;
 					console.warn("Virtual List need scrollable container", root);
@@ -65,14 +65,14 @@ class VirtualScrollManipulator {
 	init(){
 		this.listSize = this.prepareSize + Math.round(this.rootHeight / this.elMaxHeight);
 
-		var that = this;
+		const that = this;
 		function intersectionCallback(){
-			var entries = that.lastEntries;
+			const entries = that.lastEntries;
 			that.lastEntries = void 0;
 
-			var refreshed = false;
-			for(var i=entries.length-1; i>=0; i--){
-				var entry = entries[i];
+			let refreshed = false;
+			for(let i=entries.length-1; i>=0; i--){
+				const entry = entries[i];
 				if(entry.intersectionRect.height <= 1)
 					continue;
 
@@ -102,19 +102,19 @@ class VirtualScrollManipulator {
 
 		if(this.dynamicSize){
 			this.rObserver = new ResizeObserver(function(entries){
-				var elList = that.elList;
-				var refresh = elList.length;
+				const { elList } = that;
+				let refresh = elList.length;
 
 				for(var i=0; i<entries.length; i++){
 					var el = entries[i].target;
-					var newHeight = el.offsetHeight + that.elMargin;
+					const newHeight = el.offsetHeight + that.elMargin;
 
 					if(el.sf$heightPos !== newHeight){
 						that.totalHeight -= el.sf$heightPos;
 						that.totalHeight += newHeight;
 						el.sf$heightPos = newHeight;
 
-						var index = elList.indexOf(el);
+						const index = elList.indexOf(el);
 						if(index !== -1 && refresh > index)
 							refresh = index;
 
@@ -129,7 +129,7 @@ class VirtualScrollManipulator {
 					elList[refresh++].sf$scrollPos = 1;
 
 				for(var i=refresh; i<elList.length; i++){
-					var before = elList[i-1];
+					const before = elList[i-1];
 					var el = elList[i];
 					if(before === void 0){
 						el.sf$scrollPos = 1;
@@ -177,10 +177,10 @@ class VirtualScrollManipulator {
 	}
 
 	waitObservedFinish(){
-		var startMark = this.iScroller.scrollTop;
-		var endMark = startMark + this.iScroller.offsetHeight;
+		const startMark = this.iScroller.scrollTop;
+		const endMark = startMark + this.iScroller.offsetHeight;
 
-		for(var val of waitMap){
+		for(let val of waitMap){
 			if(val.sf$scrollPos < startMark || val.sf$scrollPos > endMark)
 				continue;
 
@@ -196,11 +196,11 @@ class VirtualScrollManipulator {
 		if(this.listSize === void 0)
 			return; // Haven't been initialized
 
-		var scrollTop = this.iScroller.scrollTop;
-		var elList = this.elList;
+		const { scrollTop } = this.iScroller;
+		const { elList } = this;
 
 		for(var i = Math.floor(scrollTop/this.elMaxHeight); i < elList.length; i++){
-			var scrollPos = elList[i].sf$scrollPos;
+			const scrollPos = elList[i].sf$scrollPos;
 			if(scrollPos === void 0 || scrollPos >= scrollTop)
 				break;
 		}
@@ -209,7 +209,7 @@ class VirtualScrollManipulator {
 		if(i < 0) i=0;
 		else if(i > elList.length) i = elList.length - this.listSize;
 
-		var until = i + this.listSize + this.prepareSize;
+		let until = i + this.listSize + this.prepareSize;
 		if(until > elList.length) until = elList.length;
 
 		if(i >= until){
@@ -219,9 +219,9 @@ class VirtualScrollManipulator {
 
 		this.firstCursor = i;
 
-		var expect = elList[i] || null;
-		var next = this.iTop.nextElementSibling;
-		var last;
+		const expect = elList[i] || null;
+		let next = this.iTop.nextElementSibling;
+		let last;
 
 		while(next !== expect){
 			last = next;
@@ -288,7 +288,7 @@ class VirtualScrollManipulator {
 	}
 
 	scrollTo(index){
-		var target = this.elList[index];
+		const target = this.elList[index];
 		if(!target) return;
 
 		this.iScroller.scrollTop = target.sf$scrollPos;
@@ -304,12 +304,12 @@ class VirtualScrollManipulator {
 Object.assign(VirtualScrollManipulator.prototype, {
 	startInjection(){
 		// console.log(this.elList);
-		var elList = this.elList;
-		var n = this.listSize;
+		const { elList } = this;
+		let n = this.listSize;
 		if(n > elList.length)
 			n = elList.length;
 
-		for (var i = 0; i < n; i++){
+		for (let i = 0; i < n; i++){
 			this.iRoot.insertBefore(elList[i], this.iBottom);
 			this.newElementInit(elList[i], i-1);
 		}
@@ -386,7 +386,7 @@ Object.assign(VirtualScrollManipulator.prototype, {
 	},
 
 	removeRange(index, other){
-		for (var i = index; i < other; i++) {
+		for (let i = index; i < other; i++) {
 			this.totalHeight -= this.elList[i].sf$heightPos;
 		}
 
@@ -415,10 +415,10 @@ Object.assign(VirtualScrollManipulator.prototype, {
 	},
 
 	recalculateElementData(index){
-		var elList = this.elList;
-		for (var i = index+1; i < elList.length; i++) {
-			var before = elList[i-1];
-			var now = elList[i];
+		const { elList } = this;
+		for (let i = index+1; i < elList.length; i++) {
+			const before = elList[i-1];
+			const now = elList[i];
 			now.sf$scrollPos = before.sf$scrollPos + before.sf$heightPos;
 		}
 	},
@@ -435,9 +435,9 @@ class VirtualScroll{
 
 	_proxying(name, args){
 		if(this.$EM.constructor === ElementManipulatorProxy){
-			var list = this.$EM.list;
-			var val;
-			for (var i = 0; i < list.length; i++)
+			const { list } = this.$EM;
+			let val;
+			for (let i = 0; i < list.length; i++)
 				val = VirtualScrollManipulator.prototype[name].apply(list[i].$VSM, args);
 			return val;
 		}
@@ -466,10 +466,10 @@ class VirtualScroll{
 }
 
 ;(function(){
-	var styleInitialized = false;
+	let styleInitialized = false;
 	internal.addScrollerStyle = function(){
 		if(styleInitialized === false){
-			var style = document.getElementById('sf-styles');
+			let style = document.getElementById('sf-styles');
 
 			if(!style){
 				style = document.createElement('style');
@@ -499,10 +499,10 @@ class VirtualScroll{
 		}
 	}
 
-	var isScroller = /auto|scroll|overlay|hidden/;
+	const isScroller = /auto|scroll|overlay|hidden/;
 	internal.findScrollerElement = function(el){
-		var doc = el.ownerDocument;
-		var win = doc.defaultView;
+		const doc = el.ownerDocument;
+		const win = doc.defaultView;
 		if(!win) return null;
 
 		while(el !== null && isScroller.test(win.getComputedStyle(el).overflow) === false){

--- a/src/sf-window.js
+++ b/src/sf-window.js
@@ -2,11 +2,11 @@
 // For using as remote, developer should build
 // their own auth or communication system
 
-var headerTags = '';
-var windowDestroyListener = false;
+let headerTags = '';
+let windowDestroyListener = false;
 
 function winDestroy(win){
-	var opt = win.winOptions;
+	const opt = win.winOptions;
 	if(opt.onclose && opt.onclose() === false){
 		ev.preventDefault();
 		return false;
@@ -20,7 +20,7 @@ function winDestroy(win){
 	console.log(`%c[${opt.title}]`, "color: #9bff82", "Closed!");
 }
 
-var reqAnimFrame = window.requestAnimationFrame;
+const reqAnimFrame = window.requestAnimationFrame;
 function firstInitSFWindow(){
 	window.addEventListener('focus', function(){
 		window.requestAnimationFrame = reqAnimFrame;
@@ -29,25 +29,25 @@ function firstInitSFWindow(){
 
 sf.window = {
 	list:{},
-	destroy:function(id){
+	destroy(id){
 		if(id !== void 0)
 			winDestroy(this.list[id]);
 		else{
-			var list = this.list;
-			for(var k in list)
+			const { list } = this;
+			for(let k in list)
 				winDestroy(list[k]);
 		}
 
 		window.requestAnimationFrame = reqAnimFrame;
 	},
-	create:function(options, onLoaded){
+	create(options, onLoaded){
 		if(options === void 0)
 			options = {};
 
 		if(options.id === void 0)
 			options.id = Math.round(Math.random()*1000) + String(Date.now()).slice(3);
 
-		var winID = options.id;
+		const winID = options.id;
 		if(windowDestroyListener === false){
 			windowDestroyListener = true;
 			window.addEventListener('beforeunload', function(){
@@ -55,7 +55,7 @@ sf.window = {
 			});
 		}
 
-		var template;
+		let template;
 		if(options.templateHTML)
 			template = options.templateHTML;
 		else if(options.templatePath)
@@ -67,23 +67,23 @@ sf.window = {
 		if(template === void 0)
 			return console.error("Template not found") && false;
 
-		var windowFeatures = `width=${options.width || 500},height=${options.height || 400}`;
-		var linker = window.open(window.location.origin+(options.route || ''), '', windowFeatures);
+		const windowFeatures = `width=${options.width || 500},height=${options.height || 400}`;
+		const linker = window.open(window.location.origin+(options.route || ''), '', windowFeatures);
 
 		if(linker === null)
 			return console.error("It seems the popup was blocked by the browser") && false;
 
 		if(headerTags === ''){
 			headerTags = $('script[src*="scarletsframe"]')[0].outerHTML;
-			var styles = $('link, style');
+			const styles = $('link, style');
 
-			for (var i = 0; i < styles.length; i++)
+			for (let i = 0; i < styles.length; i++)
 				headerTags += styles[i].outerHTML;
 		}
 
 		linker.winOptions = options;
 
-		var windows = this.list;
+		const windows = this.list;
 		linker.loaded = function(){
 			windows[winID] = linker;
 
@@ -99,15 +99,15 @@ sf.window = {
 			// Component
 			portComponentDefinition(linker, sf.component.registered, linker.sf.component.registered);
 
-			var spaces = sf.space.list;
-			for(var name in spaces){
-				var space = spaces[name];
-				var ref = new linker.sf.space(name, {
+			const spaces = sf.space.list;
+			for(let name in spaces){
+				const space = spaces[name];
+				const ref = new linker.sf.space(name, {
 					templatePath: space.templatePath
 				});
 
 				// Model
-				for(var id in space.list)
+				for(let id in space.list)
 					ref.list[id].root = space[id].root;
 
 				// Component
@@ -137,10 +137,10 @@ sf.window = {
 
 			sf.lang.init(linker.document.body);
 
-			for(var ev in windowEv){
-				var callbackList = windowEv[ev];
-				for (var i = 0; i < callbackList.length; i++) {
-					var evCallback = callbackList[i];
+			for(let ev in windowEv){
+				const callbackList = windowEv[ev];
+				for (let i = 0; i < callbackList.length; i++) {
+					const evCallback = callbackList[i];
 					linker.addEventListener(ev, evCallback, evCallback.options);
 				}
 			}
@@ -174,7 +174,7 @@ sf.window = {
 
 		return true;
 	},
-	source:function(lists, ev){
+	source(lists, ev){
 		if(ev === void 0)
 			ev = window.event;
 
@@ -184,8 +184,8 @@ sf.window = {
 		if(lists === void 0)
 			return lists.view;
 
-		var doc = ev.view.document;
-		for (var i = 0; i < lists.length; i++) {
+		const doc = ev.view.document;
+		for (let i = 0; i < lists.length; i++) {
 			if(lists[i].ownerDocument === doc)
 				return lists[i];
 		}
@@ -197,17 +197,17 @@ sf.window = {
 var windowEv = {};
 
 function portComponentDefinition(linker, from, into){
-	for(var name in from){
-		var ref = into[name] = from[name].slice(0);
+	for(let name in from){
+		const ref = into[name] = from[name].slice(0);
 
 		if(ref[3] !== void 0){
 			if(ref[3].constructor === Object){
-				var template = Object.create(ref[3]);
+				const template = Object.create(ref[3]);
 				ref[3] = template;
 				template.html = $.parseElement(template.html.outerHTML)[0];
 			}
 			else{
-				var tempDOM = ref[3].tempDOM;
+				const { tempDOM } = ref[3];
 				ref[3] = $.parseElement(ref[3].outerHTML)[0];
 				ref[3].tempDOM = tempDOM;
 			}


### PR DESCRIPTION
## Description
- Use ES6 syntax in the source code
- Fix removeOldMap
- Fix babel compilation

## Why
You should use ES6 syntax in your library. You supply babeled code, so you don't need to stikc to the old syntax in the source code.

- declarations.block-scope: Transform `var` into `let` and `const` as 
appropriate.
- functions.arrow         : Transform regular functions to arrow 
functions as appropriate.
- objects.concise         : Use concise object property method syntax.
- objects.destructuring   : Transform some declarations and assignments 
to the more compact destructuring form.
- objects.shorthand       : Use shorthand notation for object 
properties.
- strings.template        : Transforms manual string concatenation into 
template strings.

```ps1
❯ npm install -g esnext
❯ $all= (ls -r )
foreach($obj in $all) {
	if ($obj.extension -eq '.js') {
		  $file = $obj.fullname
		  esnext -o $file $file -b modules.commonjs
	 }
}
```