### PR TITLE
un-iife sf-url

### DIFF
--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -18,16 +18,19 @@ url.data = [];
 url.paths = '/';
 
 // Push into latest history
-url.push = function(){
+function push(){
 	window.history.pushState((window.history.state || 0) + 1, '', self());
 }
+url.push = push;
 
 // Remove next history and change current history
-url.replace = function(){
+function replace(){
 	window.history.replaceState(window.history.state, '', self());
 }
 
-url.get = function(name, index){
+url.replace = replace;
+
+function get(name, index){
 	url.parse();
 
 	if(name.constructor === Number)
@@ -39,7 +42,9 @@ url.get = function(name, index){
 	return hashes[name].split('/')[index+1];
 }
 
-url.parse = function(url){
+url.get = get;
+
+function parse(url){
 	if(url !== void 0){
 		const data = {hashes:{}};
 
@@ -69,5 +74,7 @@ url.parse = function(url){
 	url.paths = window.location.pathname;
 	return self;
 }
+
+url.parse = parse;
 
 url.parse();

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -83,3 +83,6 @@ function parse(url){
 
 exports.parse = parse;
 url.parse();
+
+// TODO for backwards compatibility until we fix other files
+sf.url = exports;

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -14,8 +14,13 @@ function url(){
 exports.url = url;
 
 let hashes = url.hashes = {};
+exports.hashes = hashes;
+
 url.data = [];
+exports.data = url.data;
+
 url.paths = '/';
+exports.paths = url.paths;
 
 // Push into latest history
 function push(){

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -6,32 +6,32 @@ function url(){
 		hashes_ += `#${keys}${hashes[keys]}`;
 	}
 
-	const data_ = `|${self.data.join('|')}`;
+	const data_ = `|${url.data.join('|')}`;
 
-	return self.paths + hashes_ + (data_.length !== 1 ? data_ : '');
+	return url.paths + hashes_ + (data_.length !== 1 ? data_ : '');
 };
 
 sf.url = url;
 
-let hashes = self.hashes = {};
-self.data = [];
-self.paths = '/';
+let hashes = url.hashes = {};
+url.data = [];
+url.paths = '/';
 
 // Push into latest history
-self.push = function(){
+url.push = function(){
 	window.history.pushState((window.history.state || 0) + 1, '', self());
 }
 
 // Remove next history and change current history
-self.replace = function(){
+url.replace = function(){
 	window.history.replaceState(window.history.state, '', self());
 }
 
-self.get = function(name, index){
-	self.parse();
+url.get = function(name, index){
+	url.parse();
 
 	if(name.constructor === Number)
-		return self.paths.split('/')[name+1];
+		return url.paths.split('/')[name+1];
 
 	if(hashes[name] === void 0)
 		return;
@@ -39,7 +39,7 @@ self.get = function(name, index){
 	return hashes[name].split('/')[index+1];
 }
 
-self.parse = function(url){
+url.parse = function(url){
 	if(url !== void 0){
 		const data = {hashes:{}};
 
@@ -56,18 +56,18 @@ self.parse = function(url){
 		return data;
 	}
 
-	self.data = window.location.hash.split('|');
-	var hashes_ = self.data.shift().split('#');
+	url.data = window.location.hash.split('|');
+	var hashes_ = url.data.shift().split('#');
 
-	hashes = self.hashes = {};
+	hashes = url.hashes = {};
 	for (var i = 1; i < hashes_.length; i++) {
 		var temp = hashes_[i].split('/');
 		hashes[temp.shift()] = `/${temp.join('/')}`;
 	}
 
 	// Paths
-	self.paths = window.location.pathname;
+	url.paths = window.location.pathname;
 	return self;
 }
 
-self.parse();
+url.parse();

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -1,4 +1,3 @@
-;(function(){
 const self = sf.url = function(){
 	// Hashes
 	let hashes_ = '';
@@ -70,5 +69,3 @@ self.parse = function(url){
 }
 
 self.parse();
-
-})();

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -1,4 +1,4 @@
-const self = sf.url = function(){
+function url(){
 	// Hashes
 	let hashes_ = '';
 	for(let keys in hashes){
@@ -10,6 +10,8 @@ const self = sf.url = function(){
 
 	return self.paths + hashes_ + (data_.length !== 1 ? data_ : '');
 };
+
+sf.url = url;
 
 let hashes = self.hashes = {};
 self.data = [];

--- a/src/sf-url.js
+++ b/src/sf-url.js
@@ -11,7 +11,7 @@ function url(){
 	return url.paths + hashes_ + (data_.length !== 1 ? data_ : '');
 };
 
-sf.url = url;
+exports.url = url;
 
 let hashes = url.hashes = {};
 url.data = [];
@@ -21,14 +21,15 @@ url.paths = '/';
 function push(){
 	window.history.pushState((window.history.state || 0) + 1, '', self());
 }
-url.push = push;
+
+exports.push = push;
 
 // Remove next history and change current history
 function replace(){
 	window.history.replaceState(window.history.state, '', self());
 }
 
-url.replace = replace;
+exports.replace = replace;
 
 function get(name, index){
 	url.parse();
@@ -42,7 +43,7 @@ function get(name, index){
 	return hashes[name].split('/')[index+1];
 }
 
-url.get = get;
+exports.get = get;
 
 function parse(url){
 	if(url !== void 0){
@@ -75,6 +76,5 @@ function parse(url){
 	return self;
 }
 
-url.parse = parse;
-
+exports.parse = parse;
 url.parse();

--- a/src/sf-views.js
+++ b/src/sf-views.js
@@ -1,3 +1,5 @@
+const SfUrl = require("./sf-url");
+
 class SFPageView extends HTMLElement{}
 if(window.sf$proxy)
 	SFPageView._ref = window.sf$proxy.SFPageView;
@@ -183,7 +185,7 @@ const self = sf.views = function View(selector, name){
 
 	// Init current URL as current View Path
 	if(name === slash)
-		self.currentPath = sf.url.paths;
+		self.currentPath = SfUrl.paths;
 	else if(name === false)
 		self.currentPath = '';
 	else{
@@ -339,12 +341,12 @@ const self = sf.views = function View(selector, name){
 
 				if(name === slash && !rootDOM.childElementCount){
 					self.currentPath = '';
-					firstRouted = self.goto(sf.url.paths);
+					firstRouted = self.goto(SfUrl.paths);
 				}
 
 				if(pendingAutoRoute){
-					if(sf.url.hashes[name] !== void 0)
-						firstRouted = self.goto(sf.url.hashes[name]);
+					if(SfUrl.hashes[name] !== void 0)
+						firstRouted = self.goto(SfUrl.hashes[name]);
 					else
 						firstRouted = self.goto('/');
 
@@ -515,13 +517,13 @@ const self = sf.views = function View(selector, name){
 			return;
 
 		if(name === slash)
-			sf.url.paths = path;
+			SfUrl.paths = path;
 		else if(name)
-			sf.url.hashes[name] = path;
+			SfUrl.hashes[name] = path;
 
 		// This won't trigger popstate event
 		if(!disableHistoryPush && _routeCount === void 0 && name !== false)
-			sf.url.push();
+			SfUrl.push();
 
 		// Check if view was exist
 		if(rootDOM.isConnected === false){
@@ -898,8 +900,8 @@ const self = sf.views = function View(selector, name){
 
 self.list = {};
 self.goto = function(url){
-	const parsed = sf.url.parse(url);
-	sf.url.data = parsed.data;
+	const parsed = SfUrl.parse(url);
+	SfUrl.data = parsed.data;
 
 	const views = self.list;
 


### PR DESCRIPTION
This convert sf-url from iife. As I mentioned, this is very important for tree shaking. People care a lot about the size of the libraries if you care about increasing the number of people who actually use your library.

I am doing this as an example, so you get familiar with the steps. When all the modules are converted to commonjs, then converting them to ES modules is easy. 

FYI, JQuery has already converted all of its code to EsModules. 

